### PR TITLE
Revert "Add /hello test endpoint (#16)"

### DIFF
--- a/tocopedia-backend/src/app.js
+++ b/tocopedia-backend/src/app.js
@@ -35,10 +35,6 @@ app.get("/", async (req, res) => {
   res.send({ status: "success" });
 });
 
-app.get("/hello", async (req, res) => {
-  res.send({ message: "hello world" });
-});
-
 app.listen(PORT, () => {
   console.log(`server listening on port ${PORT}`);
 });


### PR DESCRIPTION
## Summary
- Reverts the `/hello` test endpoint added in #16
- That endpoint was only added to verify the CI/CD pipeline and is no longer needed

## Test plan
- [ ] Confirm `/hello` route no longer exists in `app.js`
- [ ] Verify existing routes are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)