### PR TITLE
Remove APP_PORT secret, hardcode PORT=3000

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -22,7 +22,7 @@ jobs:
             cd tocopedia-backend
 
             cat > .env <<EOL
-            PORT=${{ secrets.APP_PORT }}
+            PORT=3000
             MONGODB_URL=${{ secrets.MONGODB_URL }}
             JWT_SECRET=${{ secrets.JWT_SECRET }}
             CLOUDFLARE_TUNNEL_TOKEN=${{ secrets.CLOUDFLARE_TUNNEL_TOKEN }}


### PR DESCRIPTION
## Summary
- Hardcode `PORT=3000` in deploy workflow instead of reading from `APP_PORT` secret
- `APP_PORT` GitHub secret can be deleted after merging

## Test plan
- [x] CI deploy still writes correct `.env` with `PORT=3000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)