### PR TITLE
Remove local profile from docker-compose

### DIFF
--- a/tocopedia-backend/docker-compose.yml
+++ b/tocopedia-backend/docker-compose.yml
@@ -7,6 +7,9 @@ services:
       - "${PORT:-3000}:${PORT:-3000}"
     env_file:
       - .env
+    depends_on:
+      mongo:
+        condition: service_healthy
     restart: unless-stopped
 
   mongo:
@@ -21,8 +24,6 @@ services:
       timeout: 5s
       retries: 5
     restart: unless-stopped
-    profiles:
-      - local
 
   seed:
     build:
@@ -33,8 +34,6 @@ services:
     depends_on:
       mongo:
         condition: service_healthy
-    profiles:
-      - local
 
 volumes:
   mongo_data:

--- a/tocopedia-backend/package.json
+++ b/tocopedia-backend/package.json
@@ -7,7 +7,7 @@
     "test": "jest --forceExit --detectOpenHandles",
     "dev": "env-cmd -f ./config/dev.env nodemon src/app.js",
     "init": "env-cmd -f ./config/dev.env node src/init.js",
-    "seed": "docker compose --profile local run --rm seed",
+    "seed": "docker compose run --rm seed",
     "start": "node src/app.js"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- Remove `profiles: [local]` from `docker-compose.yml` so `docker compose up` starts api + mongo without needing `--profile local`
- Add `depends_on` with health check so api waits for mongo
- Update seed script in package.json to drop `--profile local` flag
- Production continues using `docker-compose.prod.yml` (unchanged)

## Test plan
- [ ] `docker compose up` starts both api and mongo
- [ ] `npm run seed` seeds the local database
- [ ] CI/CD still uses `docker-compose.prod.yml` for deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)