### PR TITLE
Fix CI OOM: increase Gradle heap and disable Jetifier

### DIFF
--- a/tocopedia-flutter/android/gradle.properties
+++ b/tocopedia-flutter/android/gradle.properties
@@ -1,3 +1,3 @@
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx4G
 android.useAndroidX=true
-android.enableJetifier=true
+android.enableJetifier=false


### PR DESCRIPTION
## Summary
- Increase Gradle JVM heap from 1536M to 4G to prevent OOM on CI runners
- Disable Jetifier (`android.enableJetifier=false`) — unnecessary for pure AndroidX projects and was the main trigger of OOM due to processing large Flutter engine JARs

## Test plan
- [x] Local release build verified successful
- [x] CI workflow triggered manually on this branch: https://github.com/derryltaufik/tocopedia/actions/runs/24139493156

🤖 Generated with [Claude Code](https://claude.com/claude-code)