### PR TITLE
Fix release workflow permissions for APK upload

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -14,6 +14,9 @@ on:
         required: true
         default: "1"
 
+permissions:
+  contents: write
+
 jobs:
   build-android:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `permissions: contents: write` to the build-release workflow
- Fixes `softprops/action-gh-release` failing with "Resource not accessible by integration" when uploading APK to GitHub release

## Context
The v0.0.1 release build ([run #24140052916](https://github.com/derryltaufik/tocopedia/actions/runs/24140052916)) built the APK successfully but failed at the upload step because the workflow lacked write permissions to the release.

## Test plan
- [x] Merge this PR
- [ ] Delete the failed v0.0.1 release and recreate it to trigger the workflow
- [ ] Verify APK is uploaded to the release assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)