### PR TITLE
chore(ci): upgrade GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -21,19 +21,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-qemu-action@v4
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push to GHCR
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: tocopedia-backend
           file: tocopedia-backend/Dockerfile
@@ -55,16 +55,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-qemu-action@v4
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
## Summary

- Upgrades actions in `deploy-backend.yml` to fix Node.js 20 deprecation warnings seen in [run #24096598774](https://github.com/derryltaufik/tocopedia/actions/runs/24096598774)
- Actions will be forced to run on Node.js 24 starting **June 2, 2026**

| Action | Before | After |
|--------|--------|-------|
| `docker/setup-qemu-action` | v3 | v4 |
| `docker/setup-buildx-action` | v3 | v4 |
| `docker/login-action` | v3 | v4 |
| `docker/build-push-action` | v6 | v7 |
| `aws-actions/configure-aws-credentials` | v4 | v6 |

## Test plan

- [ ] Trigger the Deploy Backend workflow manually via `workflow_dispatch` and verify it completes without Node.js 20 deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)