### PR TITLE
chore(ci): upgrade actions/checkout and actions/setup-node to Node.js 24

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -17,11 +17,14 @@ on:
 permissions:
   contents: write
 
+permissions:
+  contents: write
+
 jobs:
   build-android:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: subosito/flutter-action@v2
         with:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -17,9 +17,6 @@ on:
 permissions:
   contents: write
 
-permissions:
-  contents: write
-
 jobs:
   build-android:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -11,7 +11,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: subosito/flutter-action@v2
         with:

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -10,9 +10,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
 


### PR DESCRIPTION
## Summary

Upgrades remaining `actions/checkout` and `actions/setup-node` usages across all workflows to fix Node.js 20 deprecation warnings. Actions will be forced to Node.js 24 starting **June 2, 2026**.

| Workflow | Action | Before | After |
|----------|--------|--------|-------|
| `build-release.yml` | `actions/checkout` | v4 | v6 |
| `deploy-frontend.yml` | `actions/checkout` | v4 | v6 |
| `test-backend.yml` | `actions/checkout` | v4 | v6 |
| `test-backend.yml` | `actions/setup-node` | v4 | v6 |

> Note: `softprops/action-gh-release@v2` and `cloudflare/wrangler-action@v3` still use Node.js 20 internally but have no newer major version available yet — nothing to upgrade there.

Related: #48 (upgrades docker/* and aws-actions in `deploy-backend.yml`)

## Test plan

- [ ] Trigger each workflow manually and verify no Node.js 20 deprecation warnings appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)