### PR TITLE
fix: enforce Content-Type header in S3 presigned URL signature

### DIFF
--- a/tocopedia-backend/src/__tests__/unit/services/s3.test.js
+++ b/tocopedia-backend/src/__tests__/unit/services/s3.test.js
@@ -44,6 +44,14 @@ describe("S3 Service", () => {
       expect(mockGetSignedUrl).toHaveBeenCalledTimes(1);
     });
 
+    it("should sign content-type header to enforce MIME type on S3 PUT", async () => {
+      await getPresignedUploadUrl("image/jpeg", ".jpg");
+
+      const [, , options] = mockGetSignedUrl.mock.calls[0];
+      expect(options.signableHeaders).toBeInstanceOf(Set);
+      expect(options.signableHeaders.has("content-type")).toBe(true);
+    });
+
     it("should reject invalid content type", async () => {
       await expect(
         getPresignedUploadUrl("text/html", ".html")

--- a/tocopedia-backend/src/services/s3.js
+++ b/tocopedia-backend/src/services/s3.js
@@ -58,6 +58,7 @@ const getPresignedUploadUrl = async (contentType, fileExtension) => {
 
   const presignedUrl = await getSignedUrl(s3Presign, command, {
     expiresIn: PRESIGN_EXPIRES_IN,
+    signableHeaders: new Set(["content-type"]),
   });
 
   const baseUrl =


### PR DESCRIPTION
## Problem

When testing the presigned URL flow, the `Content-Type` header was not enforced by S3. A client could obtain a presigned URL for `image/jpeg` then upload any file type (e.g. `application/pdf`) and S3 would accept it with HTTP 200.

Root cause: the presigned URL's signature only covered `host` (`X-Amz-SignedHeaders=host`), so S3 had no way to verify the `Content-Type` on the actual PUT request.

## Fix

Add `signableHeaders: new Set(["content-type"])` to the `getSignedUrl` options in `s3.js`. This includes `content-type` in the AWS signature, so the presigned URL is bound to the exact content type validated at request time. Any PUT with a different `Content-Type` will be rejected by S3 with HTTP 403.

## Changes

- `src/services/s3.js` — add `signableHeaders` to `getSignedUrl` options
- `src/__tests__/unit/services/s3.test.js` — add test asserting `content-type` is in `signableHeaders`

## Test plan

### Automated (24 tests — all pass)
- [x] Existing 13 unit tests for S3 service pass
- [x] Existing 11 integration tests for upload endpoints pass
- [x] New unit test: asserts `signableHeaders` contains `"content-type"`

### Manual E2E against `https://api.tocopedia.com`

| Test | Expected | Result |
|---|---|---|
| GET presigned URL | 200 + URL with `content-type` in `X-Amz-SignedHeaders` | ✅ |
| PUT with correct `Content-Type: image/jpeg` | 200 | ✅ |
| PUT with wrong `Content-Type: application/pdf` | 403 | ✅ (was HTTP 200 before fix) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)