### PR TITLE
feat(web): pulse splash branding while main.dart.js loads

### DIFF
--- a/tocopedia-flutter/web/index.html
+++ b/tocopedia-flutter/web/index.html
@@ -39,6 +39,15 @@
   <link rel="stylesheet" type="text/css" href="splash/style.css">
   <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" name="viewport">
   <script src="splash/splash.js"></script>
+  <style>
+    #splash-branding {
+      animation: splash-brand-pulse 1.4s ease-in-out infinite;
+    }
+    @keyframes splash-brand-pulse {
+      0%, 100% { opacity: 1; }
+      50%      { opacity: 0.35; }
+    }
+  </style>
 </head>
 <body>  <picture id="splash-branding">
     <source srcset="splash/img/branding-1x.png 1x, splash/img/branding-2x.png 2x, splash/img/branding-3x.png 3x, splash/img/branding-4x.png 4x" media="(prefers-color-scheme: light)">
@@ -48,7 +57,7 @@
       <source srcset="splash/img/light-1x.png 1x, splash/img/light-2x.png 2x, splash/img/light-3x.png 3x, splash/img/light-4x.png 4x" media="(prefers-color-scheme: light)">
       <source srcset="splash/img/dark-1x.png 1x, splash/img/dark-2x.png 2x, splash/img/dark-3x.png 3x, splash/img/dark-4x.png 4x" media="(prefers-color-scheme: dark)">
       <img class="center" aria-hidden="true" src="splash/img/light-1x.png" alt="">
-  </picture>                                      
+  </picture>
   <script>
     window.addEventListener('load', function(ev) {
       // Download main.dart.js


### PR DESCRIPTION
## Summary
- Flutter web takes ~10s to download `main.dart.js`, and the static splash screen made users suspect the page was broken.
- Added a 1.4s opacity pulse on `#splash-branding` so the existing tocopedia wordmark visibly breathes during load, then it gets removed normally by `flutter_native_splash` once the app mounts.
- Change is scoped to an inline `<style>` block in `web/index.html` so the regenerated `web/splash/` assets are untouched.

## Test plan
- [x] `flutter run -d chrome` → hard refresh and confirm the bottom tocopedia wordmark pulses while loading.
- [x] Confirm the pulse stops and the splash disappears once the app finishes booting.
- [x] Check both light and dark `prefers-color-scheme` so the correct branding variant still shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)