### PR TITLE
ci: add Flutter analyze and test workflow

### DIFF
--- a/.github/workflows/test-flutter.yml
+++ b/.github/workflows/test-flutter.yml
@@ -1,0 +1,29 @@
+name: Test Flutter
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "tocopedia-flutter/**"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.41.6"
+
+      - name: Install dependencies
+        working-directory: tocopedia-flutter
+        run: flutter pub get
+
+      - name: Analyze
+        working-directory: tocopedia-flutter
+        run: flutter analyze
+
+      - name: Run tests
+        working-directory: tocopedia-flutter
+        run: flutter test

--- a/.github/workflows/test-flutter.yml
+++ b/.github/workflows/test-flutter.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - "tocopedia-flutter/**"
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- Add `test-flutter.yml` workflow that runs on PRs touching `tocopedia-flutter/**`
- Runs `flutter pub get`, `flutter analyze`, and `flutter test` on Flutter 3.41.6 (matches `build-release.yml`)

## Test plan
- [ ] Open a PR modifying a file under `tocopedia-flutter/` and confirm the workflow triggers
- [ ] Verify analyze and test steps pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)