### PR TITLE
ci: soften flutter analyze to non-fatal infos and warnings

### DIFF
--- a/.github/workflows/test-flutter.yml
+++ b/.github/workflows/test-flutter.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Analyze
         working-directory: tocopedia-flutter
-        run: flutter analyze
+        run: flutter analyze --no-fatal-infos --no-fatal-warnings
 
       - name: Run tests
         working-directory: tocopedia-flutter


### PR DESCRIPTION
## Summary
- The first run of `test-flutter.yml` failed at the analyze step: 145 pre-existing info/warning lints in the Flutter codebase caused `flutter analyze` to exit non-zero, preventing `flutter test` from ever running
- Adds `--no-fatal-infos --no-fatal-warnings` so analyze still surfaces issues in the log but only fails CI on real errors
- Test job will now actually run

## Test plan
- [ ] Confirm Test Flutter workflow's analyze step succeeds and the test step executes