### PR TITLE
fix: resolve all flutter analyze warnings

### DIFF
--- a/.github/workflows/test-flutter.yml
+++ b/.github/workflows/test-flutter.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Analyze
         working-directory: tocopedia-flutter
-        run: flutter analyze --no-fatal-infos --no-fatal-warnings
+        run: flutter analyze --no-fatal-infos
 
       - name: Run tests
         working-directory: tocopedia-flutter

--- a/tocopedia-flutter/lib/injection.dart
+++ b/tocopedia-flutter/lib/injection.dart
@@ -235,7 +235,6 @@ void init() {
       logout: locator(),
       saveUser: locator(),
       autoLogin: locator(),
-      getUser: locator(),
       updateUser: locator(),
     ),
   );
@@ -263,7 +262,6 @@ void init() {
   locator.registerFactoryParam(
     (String? param1, _) => CartProvider(
       addToCart: locator(),
-      clearCart: locator(),
       getCart: locator(),
       removeFromCart: locator(),
       updateCart: locator(),
@@ -271,7 +269,6 @@ void init() {
       unselectCartItem: locator(),
       selectSeller: locator(),
       unselectSeller: locator(),
-      getProduct: locator(),
       authToken: param1,
     ),
   );
@@ -304,7 +301,6 @@ void init() {
     (String? param1, _) => AddressProvider(
       addAddress: locator(),
       deleteAddress: locator(),
-      getAddress: locator(),
       getUserAddresses: locator(),
       updateAddress: locator(),
       authToken: param1,
@@ -324,7 +320,6 @@ void init() {
     (String? param1, _) => ReviewProvider(
       getBuyerReviews: locator(),
       getProductReviews: locator(),
-      getSellerReviews: locator(),
       addReview: locator(),
       updateReview: locator(),
       getReview: locator(),

--- a/tocopedia-flutter/lib/presentation/providers/address_provider.dart
+++ b/tocopedia-flutter/lib/presentation/providers/address_provider.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:tocopedia/domains/entities/address.dart';
 import 'package:tocopedia/domains/use_cases/address/add_address.dart';
 import 'package:tocopedia/domains/use_cases/address/delete_address.dart';
-import 'package:tocopedia/domains/use_cases/address/get_address.dart';
 import 'package:tocopedia/domains/use_cases/address/get_user_addresses.dart';
 import 'package:tocopedia/domains/use_cases/address/update_address.dart';
 import 'package:tocopedia/presentation/helper_variables/provider_state.dart';
@@ -11,7 +10,6 @@ class AddressProvider with ChangeNotifier {
   final AddAddress _addAddress;
   final UpdateAddress _updateAddress;
   final GetUserAddresses _getUserAddresses;
-  final GetAddress _getAddress;
   final DeleteAddress _deleteAddress;
   final String? _authToken;
 
@@ -29,12 +27,10 @@ class AddressProvider with ChangeNotifier {
       {required AddAddress addAddress,
       required UpdateAddress updateAddress,
       required GetUserAddresses getUserAddresses,
-      required GetAddress getAddress,
       required DeleteAddress deleteAddress,
       required String? authToken})
       : _addAddress = addAddress,
         _updateAddress = updateAddress,
-        _getAddress = getAddress,
         _getUserAddresses = getUserAddresses,
         _deleteAddress = deleteAddress,
         _authToken = authToken;
@@ -129,6 +125,6 @@ class AddressProvider with ChangeNotifier {
   }
 
   bool _verifyToken() {
-    return (_authToken != null && _authToken!.isNotEmpty);
+    return (_authToken != null && _authToken.isNotEmpty);
   }
 }

--- a/tocopedia-flutter/lib/presentation/providers/cart_provider.dart
+++ b/tocopedia-flutter/lib/presentation/providers/cart_provider.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:tocopedia/domains/entities/cart.dart';
 import 'package:tocopedia/domains/use_cases/cart/add_to_cart.dart';
-import 'package:tocopedia/domains/use_cases/cart/clear_cart.dart';
 import 'package:tocopedia/domains/use_cases/cart/get_cart.dart';
 import 'package:tocopedia/domains/use_cases/cart/remove_from_cart.dart';
 import 'package:tocopedia/domains/use_cases/cart/select_cart_item.dart';
@@ -11,7 +10,6 @@ import 'package:tocopedia/domains/use_cases/cart/select_seller.dart';
 import 'package:tocopedia/domains/use_cases/cart/unselect_cart_item.dart';
 import 'package:tocopedia/domains/use_cases/cart/unselect_seller.dart';
 import 'package:tocopedia/domains/use_cases/cart/update_cart.dart';
-import 'package:tocopedia/domains/use_cases/product/get_product.dart';
 import 'package:tocopedia/presentation/helper_variables/provider_state.dart';
 
 class CartProvider with ChangeNotifier {
@@ -19,8 +17,6 @@ class CartProvider with ChangeNotifier {
   final AddToCart _addToCart;
   final RemoveFromCart _removeFromCart;
   final UpdateCart _updateCart;
-  final ClearCart _clearCart;
-  final GetProduct _getProduct;
   final SelectCartItem _selectCartItem;
   final UnselectCartItem _unselectCartItem;
   final SelectSeller _selectSeller;
@@ -80,8 +76,6 @@ class CartProvider with ChangeNotifier {
       required AddToCart addToCart,
       required RemoveFromCart removeFromCart,
       required UpdateCart updateCart,
-      required ClearCart clearCart,
-      required GetProduct getProduct,
       required SelectCartItem selectCartItem,
       required UnselectCartItem unselectCartItem,
       required SelectSeller selectSeller,
@@ -91,8 +85,6 @@ class CartProvider with ChangeNotifier {
         _addToCart = addToCart,
         _removeFromCart = removeFromCart,
         _updateCart = updateCart,
-        _clearCart = clearCart,
-        _getProduct = getProduct,
         _unselectCartItem = unselectCartItem,
         _selectCartItem = selectCartItem,
         _selectSeller = selectSeller,
@@ -241,6 +233,6 @@ class CartProvider with ChangeNotifier {
   }
 
   bool _verifyToken() {
-    return (_authToken != null && _authToken!.isNotEmpty);
+    return (_authToken != null && _authToken.isNotEmpty);
   }
 }

--- a/tocopedia-flutter/lib/presentation/providers/order_item_provider.dart
+++ b/tocopedia-flutter/lib/presentation/providers/order_item_provider.dart
@@ -169,6 +169,6 @@ class OrderItemProvider with ChangeNotifier {
   }
 
   bool _verifyToken() {
-    return (_authToken != null && _authToken!.isNotEmpty);
+    return (_authToken != null && _authToken.isNotEmpty);
   }
 }

--- a/tocopedia-flutter/lib/presentation/providers/order_provider.dart
+++ b/tocopedia-flutter/lib/presentation/providers/order_provider.dart
@@ -129,6 +129,6 @@ class OrderProvider with ChangeNotifier {
   }
 
   bool _verifyToken() {
-    return (_authToken != null && _authToken!.isNotEmpty);
+    return (_authToken != null && _authToken.isNotEmpty);
   }
 }

--- a/tocopedia-flutter/lib/presentation/providers/product_provider.dart
+++ b/tocopedia-flutter/lib/presentation/providers/product_provider.dart
@@ -237,6 +237,6 @@ class ProductProvider with ChangeNotifier {
   }
 
   bool _verifyToken() {
-    return (_authToken != null && _authToken!.isNotEmpty);
+    return (_authToken != null && _authToken.isNotEmpty);
   }
 }

--- a/tocopedia-flutter/lib/presentation/providers/review_provider.dart
+++ b/tocopedia-flutter/lib/presentation/providers/review_provider.dart
@@ -7,7 +7,6 @@ import 'package:tocopedia/domains/use_cases/review/add_review.dart';
 import 'package:tocopedia/domains/use_cases/review/get_buyer_reviews.dart';
 import 'package:tocopedia/domains/use_cases/review/get_product_reviews.dart';
 import 'package:tocopedia/domains/use_cases/review/get_review.dart';
-import 'package:tocopedia/domains/use_cases/review/get_seller_reviews.dart';
 import 'package:tocopedia/domains/use_cases/review/update_review.dart';
 import 'package:tocopedia/presentation/helper_variables/provider_state.dart';
 
@@ -15,7 +14,6 @@ class ReviewProvider with ChangeNotifier {
   final AddReview _addReview;
   final UpdateReview _updateReview;
   final GetBuyerReviews _getBuyerReviews;
-  final GetSellerReviews _getSellerReviews;
   final GetProductReviews _getProductReviews;
   final GetReview _getReview;
 
@@ -41,14 +39,12 @@ class ReviewProvider with ChangeNotifier {
 
   ReviewProvider({
     required GetProductReviews getProductReviews,
-    required GetSellerReviews getSellerReviews,
     required GetBuyerReviews getBuyerReviews,
     required AddReview addReview,
     required UpdateReview updateReview,
     required GetReview getReview,
     required String? authToken,
   })  : _getProductReviews = getProductReviews,
-        _getSellerReviews = getSellerReviews,
         _getBuyerReviews = getBuyerReviews,
         _addReview = addReview,
         _updateReview = updateReview,
@@ -180,6 +176,6 @@ class ReviewProvider with ChangeNotifier {
   }
 
   bool _verifyToken() {
-    return (_authToken != null && _authToken!.isNotEmpty);
+    return (_authToken != null && _authToken.isNotEmpty);
   }
 }

--- a/tocopedia-flutter/lib/presentation/providers/user_provider.dart
+++ b/tocopedia-flutter/lib/presentation/providers/user_provider.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:tocopedia/domains/entities/user.dart';
 import 'package:tocopedia/domains/use_cases/user/auto_login.dart';
-import 'package:tocopedia/domains/use_cases/user/get_user.dart';
 import 'package:tocopedia/domains/use_cases/user/login.dart';
 import 'package:tocopedia/domains/use_cases/user/logout.dart';
 import 'package:tocopedia/domains/use_cases/user/save_user.dart';
@@ -17,7 +16,6 @@ class UserProvider with ChangeNotifier {
   final Logout _logout;
   final SaveUser _saveUser;
   final AutoLogin _autoLogin;
-  final GetUser _getUser;
   final UpdateUser _updateUser;
 
   User? _user;
@@ -33,14 +31,12 @@ class UserProvider with ChangeNotifier {
     required Logout logout,
     required SaveUser saveUser,
     required AutoLogin autoLogin,
-    required GetUser getUser,
     required UpdateUser updateUser,
   })  : _signUp = signUp,
         _login = login,
         _logout = logout,
         _saveUser = saveUser,
         _autoLogin = autoLogin,
-        _getUser = getUser,
         _updateUser = updateUser;
 
   ProviderState _authState = ProviderState.empty;

--- a/tocopedia-flutter/lib/presentation/providers/wishlist_provider.dart
+++ b/tocopedia-flutter/lib/presentation/providers/wishlist_provider.dart
@@ -88,6 +88,6 @@ class WishlistProvider with ChangeNotifier {
   }
 
   bool _verifyToken() {
-    return (_authToken != null && _authToken!.isNotEmpty);
+    return (_authToken != null && _authToken.isNotEmpty);
   }
 }

--- a/tocopedia-flutter/test/data/data_sources/product_remote_data_source_test.dart
+++ b/tocopedia-flutter/test/data/data_sources/product_remote_data_source_test.dart
@@ -5,7 +5,6 @@ import 'package:http/http.dart' as http;
 import 'package:mocktail/mocktail.dart';
 import 'package:tocopedia/common/exception.dart';
 import 'package:tocopedia/data/data_sources/product_remote_data_source.dart';
-import 'package:tocopedia/data/models/category_model.dart';
 import 'package:tocopedia/data/models/product_model.dart';
 
 class MockHttpClient extends Mock implements http.Client {}


### PR DESCRIPTION
## Summary
- Remove redundant `!` operator in `_verifyToken()` across 7 providers (Dart type narrowing makes it unnecessary after null check)
- Remove 5 unused fields (`_getAddress`, `_clearCart`, `_getProduct`, `_getSellerReviews`, `_getUser`) along with their constructor params, initializers, and imports
- Remove unused `CategoryModel` import in test file
- Tighten CI analyze to `--no-fatal-infos` — warnings are now fatal, info-level hints still pass

## Test plan
- [x] `flutter analyze` locally shows 0 warnings (132 info-level only)
- [ ] CI `Test Flutter` workflow passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)