### PR TITLE
fix: use super parameters in widget constructors

### DIFF
--- a/tocopedia-flutter/lib/presentation/pages/common_widgets/buyer_navigation_bar.dart
+++ b/tocopedia-flutter/lib/presentation/pages/common_widgets/buyer_navigation_bar.dart
@@ -6,7 +6,7 @@ import 'package:tocopedia/presentation/pages/features/wishlist/wishlist_page.dar
 import 'package:tocopedia/presentation/pages/features/review/buyer_reviews_page.dart';
 
 class BuyerNavBar extends StatefulWidget {
-  const BuyerNavBar({Key? key}) : super(key: key);
+  const BuyerNavBar({super.key});
 
   @override
   State<BuyerNavBar> createState() => _BuyerNavBarState();

--- a/tocopedia-flutter/lib/presentation/pages/common_widgets/cart_button_appbar.dart
+++ b/tocopedia-flutter/lib/presentation/pages/common_widgets/cart_button_appbar.dart
@@ -5,8 +5,7 @@ class CartButtonAppBar extends StatelessWidget implements PreferredSizeWidget {
   final String title;
   final TabBar? bottom;
 
-  const CartButtonAppBar({Key? key, required this.title, this.bottom})
-      : super(key: key);
+  const CartButtonAppBar({super.key, required this.title, this.bottom});
 
   @override
   Widget build(BuildContext context) {

--- a/tocopedia-flutter/lib/presentation/pages/common_widgets/custom_form_field.dart
+++ b/tocopedia-flutter/lib/presentation/pages/common_widgets/custom_form_field.dart
@@ -101,14 +101,11 @@ class CheckboxFormField extends FormField<bool> {
   CheckboxFormField(
       {super.key,
       required Widget title,
-      required FormFieldSetter<bool> onSaved,
-      FormFieldValidator<bool>? validator,
-      bool initialValue = false,
+      required FormFieldSetter<bool> super.onSaved,
+      super.validator,
+      bool super.initialValue = false,
       bool autoValidate = false})
       : super(
-          onSaved: onSaved,
-          validator: validator,
-          initialValue: initialValue,
           builder: (FormFieldState<bool> state) {
             return Row(
               children: [
@@ -181,7 +178,7 @@ class QuantityField extends StatelessWidget {
   final double width;
 
   const QuantityField({
-    Key? key,
+    super.key,
     required this.controller,
     this.minimum = 1,
     this.maximum = 999999,
@@ -190,7 +187,7 @@ class QuantityField extends StatelessWidget {
     this.focusNode,
     this.autoFocus = false,
     this.width = 25,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/tocopedia-flutter/lib/presentation/pages/common_widgets/home_appbar.dart
+++ b/tocopedia-flutter/lib/presentation/pages/common_widgets/home_appbar.dart
@@ -5,7 +5,7 @@ import 'package:tocopedia/presentation/pages/common_widgets/product_search_bar.d
 class HomeAppBar extends StatelessWidget implements PreferredSizeWidget {
   final String query;
 
-  const HomeAppBar({Key? key, this.query = ""}) : super(key: key);
+  const HomeAppBar({super.key, this.query = ""});
 
   @override
   Size get preferredSize => const Size.fromHeight(kToolbarHeight);

--- a/tocopedia-flutter/lib/presentation/pages/common_widgets/images/pick_image_tile.dart
+++ b/tocopedia-flutter/lib/presentation/pages/common_widgets/images/pick_image_tile.dart
@@ -13,8 +13,7 @@ class PickImageTile extends StatelessWidget {
   final String? label;
 
   const PickImageTile(
-      {Key? key, this.label, required this.index, required this.size})
-      : super(key: key);
+      {super.key, this.label, required this.index, required this.size});
 
   void pickImage(BuildContext context) async {
     final ImageSource? imageSource = await showModalBottomSheet(
@@ -109,7 +108,7 @@ class PickImageTile extends StatelessWidget {
 }
 
 class ImageSourceSelectionBottomSheet extends StatelessWidget {
-  const ImageSourceSelectionBottomSheet({Key? key}) : super(key: key);
+  const ImageSourceSelectionBottomSheet({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/tocopedia-flutter/lib/presentation/pages/common_widgets/seller_navigation_bar.dart
+++ b/tocopedia-flutter/lib/presentation/pages/common_widgets/seller_navigation_bar.dart
@@ -4,7 +4,7 @@ import 'package:tocopedia/presentation/pages/features/seller_product/seller_view
 import 'package:tocopedia/presentation/pages/features/user/user_page.dart';
 
 class SellerNavBar extends StatefulWidget {
-  const SellerNavBar({Key? key}) : super(key: key);
+  const SellerNavBar({super.key});
 
   @override
   State<SellerNavBar> createState() => _SellerNavBarState();

--- a/tocopedia-flutter/lib/presentation/pages/common_widgets/single_child_full_page_scroll_view.dart
+++ b/tocopedia-flutter/lib/presentation/pages/common_widgets/single_child_full_page_scroll_view.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 class SingleChildFullPageScrollView extends StatelessWidget {
   final Widget? child;
 
-  const SingleChildFullPageScrollView({Key? key, this.child}) : super(key: key);
+  const SingleChildFullPageScrollView({super.key, this.child});
 
   const SingleChildFullPageScrollView.loading({super.key})
       : child = const CircularProgressIndicator();

--- a/tocopedia-flutter/lib/presentation/pages/common_widgets/status_card.dart
+++ b/tocopedia-flutter/lib/presentation/pages/common_widgets/status_card.dart
@@ -5,8 +5,7 @@ class StatusCard extends StatelessWidget {
   final String text;
   final Color color;
 
-  const StatusCard({Key? key, required this.text, required this.color})
-      : super(key: key);
+  const StatusCard({super.key, required this.text, required this.color});
 
   @override
   Widget build(BuildContext context) {

--- a/tocopedia-flutter/lib/presentation/pages/features/address/add_address_page.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/address/add_address_page.dart
@@ -8,7 +8,7 @@ import 'package:tocopedia/presentation/providers/user_provider.dart';
 class AddAddressPage extends StatefulWidget {
   static const String routeName = "addresses/add";
 
-  const AddAddressPage({Key? key}) : super(key: key);
+  const AddAddressPage({super.key});
 
   @override
   State<AddAddressPage> createState() => _AddAddressPageState();

--- a/tocopedia-flutter/lib/presentation/pages/features/address/edit_address_page.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/address/edit_address_page.dart
@@ -18,8 +18,7 @@ class EditAddressPage extends StatefulWidget {
   final bool isDefault;
 
   const EditAddressPage(
-      {Key? key, required this.address, this.isDefault = false})
-      : super(key: key);
+      {super.key, required this.address, this.isDefault = false});
 
   @override
   State<EditAddressPage> createState() => _EditAddressPageState();

--- a/tocopedia-flutter/lib/presentation/pages/features/address/view_all_addresses_page.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/address/view_all_addresses_page.dart
@@ -11,7 +11,7 @@ import 'package:tocopedia/presentation/providers/user_provider.dart';
 class ViewAllAddressesPage extends StatefulWidget {
   static const String routeName = "/addresses/view-all";
 
-  const ViewAllAddressesPage({Key? key}) : super(key: key);
+  const ViewAllAddressesPage({super.key});
 
   @override
   State<ViewAllAddressesPage> createState() => _ViewAllAddressesPageState();

--- a/tocopedia-flutter/lib/presentation/pages/features/address/widgets/single_address_card.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/address/widgets/single_address_card.dart
@@ -13,8 +13,7 @@ class SingleAddressCard extends StatelessWidget {
   final bool isDefault;
 
   const SingleAddressCard(
-      {Key? key, required this.address, this.isDefault = true})
-      : super(key: key);
+      {super.key, required this.address, this.isDefault = true});
 
   Future<void> setAsDefault(BuildContext context) async {
     await handleFutureFunction(

--- a/tocopedia-flutter/lib/presentation/pages/features/auth/auth_page.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/auth/auth_page.dart
@@ -12,7 +12,7 @@ enum AuthFormMode { signUp, login }
 class AuthPage extends StatefulWidget {
   static const String routeName = '/auth';
 
-  const AuthPage({Key? key}) : super(key: key);
+  const AuthPage({super.key});
 
   @override
   State<AuthPage> createState() => _AuthPageState();

--- a/tocopedia-flutter/lib/presentation/pages/features/cart/cart_page.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/cart/cart_page.dart
@@ -10,7 +10,7 @@ import 'package:tocopedia/presentation/helper_variables/provider_state.dart';
 class CartPage extends StatefulWidget {
   static const String routeName = "/cart";
 
-  const CartPage({Key? key}) : super(key: key);
+  const CartPage({super.key});
 
   @override
   State<CartPage> createState() => _CartPageState();

--- a/tocopedia-flutter/lib/presentation/pages/features/cart/checkout_page.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/cart/checkout_page.dart
@@ -14,7 +14,7 @@ import 'package:tocopedia/presentation/providers/user_provider.dart';
 class CheckoutPage extends StatefulWidget {
   static const String routeName = "/checkout";
 
-  const CheckoutPage({Key? key}) : super(key: key);
+  const CheckoutPage({super.key});
 
   @override
   State<CheckoutPage> createState() => _CheckoutPageState();

--- a/tocopedia-flutter/lib/presentation/pages/features/cart/widgets/address_selection_card.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/cart/widgets/address_selection_card.dart
@@ -4,12 +4,12 @@ import 'package:tocopedia/presentation/pages/common_widgets/status_card.dart';
 
 class AddressSelectionCard extends StatelessWidget {
   const AddressSelectionCard({
-    Key? key,
+    super.key,
     required this.address,
     this.isDefault = false,
     this.isSelected = true,
     this.width = 200,
-  }) : super(key: key);
+  });
 
   final Address address;
   final bool isDefault;

--- a/tocopedia-flutter/lib/presentation/pages/features/cart/widgets/cart_item_detail_tile.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/cart/widgets/cart_item_detail_tile.dart
@@ -16,11 +16,10 @@ class CartItemDetailTile extends StatefulWidget {
   final Function updateCheckBoxState;
 
   const CartItemDetailTile(
-      {Key? key,
+      {super.key,
       required this.cartItemDetail,
       required this.checkBoxNotifier,
-      required this.updateCheckBoxState})
-      : super(key: key);
+      required this.updateCheckBoxState});
 
   @override
   State<CartItemDetailTile> createState() => _CartItemDetailTileState();

--- a/tocopedia-flutter/lib/presentation/pages/features/cart/widgets/cart_item_tile.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/cart/widgets/cart_item_tile.dart
@@ -16,7 +16,7 @@ class ShopCheckboxNotifier extends ValueNotifier<bool> {
 class CartItemTile extends StatefulWidget {
   final CartItem cartItem;
 
-  const CartItemTile({Key? key, required this.cartItem}) : super(key: key);
+  const CartItemTile({super.key, required this.cartItem});
 
   @override
   State<CartItemTile> createState() => _CartItemTileState();

--- a/tocopedia-flutter/lib/presentation/pages/features/cart/widgets/checkout_item_detail_tile.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/cart/widgets/checkout_item_detail_tile.dart
@@ -9,9 +9,9 @@ class CheckoutItemDetailTile extends StatelessWidget {
   final CartItemDetail cartItemDetail;
 
   const CheckoutItemDetailTile({
-    Key? key,
+    super.key,
     required this.cartItemDetail,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/tocopedia-flutter/lib/presentation/pages/features/cart/widgets/checkout_item_tile.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/cart/widgets/checkout_item_tile.dart
@@ -6,7 +6,7 @@ import 'package:tocopedia/presentation/pages/features/cart/widgets/checkout_item
 class CheckoutItemTile extends StatelessWidget {
   final CartItem cartItem;
 
-  const CheckoutItemTile({Key? key, required this.cartItem}) : super(key: key);
+  const CheckoutItemTile({super.key, required this.cartItem});
 
   @override
   Widget build(BuildContext context) {

--- a/tocopedia-flutter/lib/presentation/pages/features/home/home_page.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/home/home_page.dart
@@ -12,7 +12,7 @@ import 'package:tocopedia/presentation/helper_variables/provider_state.dart';
 class HomePage extends StatefulWidget {
   static const String routeName = "/";
 
-  const HomePage({Key? key}) : super(key: key);
+  const HomePage({super.key});
 
   @override
   State<HomePage> createState() => _HomePageState();

--- a/tocopedia-flutter/lib/presentation/pages/features/order/view_all_orders_page.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/order/view_all_orders_page.dart
@@ -9,7 +9,7 @@ import 'package:tocopedia/presentation/helper_variables/provider_state.dart';
 class ViewAllOrdersPage extends StatefulWidget {
   static const String routeName = "/orders/view-all";
 
-  const ViewAllOrdersPage({Key? key}) : super(key: key);
+  const ViewAllOrdersPage({super.key});
 
   @override
   State<ViewAllOrdersPage> createState() => _ViewAllOrdersPageState();

--- a/tocopedia-flutter/lib/presentation/pages/features/order/view_order_page.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/order/view_order_page.dart
@@ -16,7 +16,7 @@ class ViewOrderPage extends StatefulWidget {
 
   final String orderId;
 
-  const ViewOrderPage({Key? key, required this.orderId}) : super(key: key);
+  const ViewOrderPage({super.key, required this.orderId});
 
   @override
   State<ViewOrderPage> createState() => _ViewOrderPageState();

--- a/tocopedia-flutter/lib/presentation/pages/features/order/widgets/single_order_card.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/order/widgets/single_order_card.dart
@@ -7,7 +7,7 @@ import 'package:tocopedia/presentation/pages/features/order/view_order_page.dart
 class SingleOrderCard extends StatelessWidget {
   final Order order;
 
-  const SingleOrderCard({Key? key, required this.order}) : super(key: key);
+  const SingleOrderCard({super.key, required this.order});
 
   @override
   Widget build(BuildContext context) {

--- a/tocopedia-flutter/lib/presentation/pages/features/product/view_product_page.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/product/view_product_page.dart
@@ -20,7 +20,7 @@ class ViewProductPage extends StatefulWidget {
 
   final String productId;
 
-  const ViewProductPage({Key? key, required this.productId}) : super(key: key);
+  const ViewProductPage({super.key, required this.productId});
 
   @override
   State<ViewProductPage> createState() => _ViewProductPageState();

--- a/tocopedia-flutter/lib/presentation/pages/features/product/widgets/product_image_carousel.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/product/widgets/product_image_carousel.dart
@@ -6,8 +6,7 @@ import 'package:tocopedia/presentation/pages/common_widgets/images/images_galler
 class ProductImageCarousel extends StatefulWidget {
   final List<String> images;
 
-  const ProductImageCarousel({Key? key, required this.images})
-      : super(key: key);
+  const ProductImageCarousel({super.key, required this.images});
 
   @override
   State<ProductImageCarousel> createState() => _ProductImagePreviewState();

--- a/tocopedia-flutter/lib/presentation/pages/features/product/widgets/single_product_card.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/product/widgets/single_product_card.dart
@@ -8,8 +8,7 @@ import 'package:tocopedia/presentation/pages/features/product/widgets/wishlist_a
 
 class SingleProductCard extends StatelessWidget {
   const SingleProductCard(
-      {Key? key, required this.product, this.isWishlist = false})
-      : super(key: key);
+      {super.key, required this.product, this.isWishlist = false});
 
   final Product product;
   final bool isWishlist;

--- a/tocopedia-flutter/lib/presentation/pages/features/product/widgets/wishlist_action_buttons.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/product/widgets/wishlist_action_buttons.dart
@@ -7,8 +7,7 @@ import 'package:tocopedia/presentation/providers/wishlist_provider.dart';
 class WishlistActionButtons extends StatelessWidget {
   final String productId;
 
-  const WishlistActionButtons({Key? key, required this.productId})
-      : super(key: key);
+  const WishlistActionButtons({super.key, required this.productId});
 
   Future<void> addToCart(BuildContext context) async {
     await handleFutureFunction(

--- a/tocopedia-flutter/lib/presentation/pages/features/product/widgets/wishlist_button.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/product/widgets/wishlist_button.dart
@@ -5,7 +5,7 @@ import 'package:tocopedia/presentation/helper_variables/provider_state.dart';
 import 'package:tocopedia/presentation/providers/wishlist_provider.dart';
 
 class WishlistButton extends StatefulWidget {
-  const WishlistButton({Key? key, required this.productId}) : super(key: key);
+  const WishlistButton({super.key, required this.productId});
   final String productId;
 
   @override

--- a/tocopedia-flutter/lib/presentation/pages/features/review/add_review_page.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/review/add_review_page.dart
@@ -25,10 +25,10 @@ class AddReviewPage extends StatefulWidget {
   final Review review;
 
   const AddReviewPage({
-    Key? key,
+    super.key,
     this.initialRating = 0,
     required this.review,
-  }) : super(key: key);
+  });
 
   @override
   State<AddReviewPage> createState() => _AddReviewPageState();

--- a/tocopedia-flutter/lib/presentation/pages/features/review/buyer_reviews_page.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/review/buyer_reviews_page.dart
@@ -12,7 +12,7 @@ import 'package:tocopedia/presentation/helper_variables/provider_state.dart';
 class BuyerReviewsPage extends StatefulWidget {
   static const String routeName = "/reviews/buyer";
 
-  const BuyerReviewsPage({Key? key}) : super(key: key);
+  const BuyerReviewsPage({super.key});
 
   @override
   State<BuyerReviewsPage> createState() => _BuyerReviewsPageState();

--- a/tocopedia-flutter/lib/presentation/pages/features/review/edit_review_page.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/review/edit_review_page.dart
@@ -17,9 +17,9 @@ class EditReviewPage extends StatefulWidget {
   final Review review;
 
   const EditReviewPage({
-    Key? key,
+    super.key,
     required this.review,
-  }) : super(key: key);
+  });
 
   @override
   State<EditReviewPage> createState() => _EditReviewPageState();

--- a/tocopedia-flutter/lib/presentation/pages/features/review/product_reviews_page.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/review/product_reviews_page.dart
@@ -13,7 +13,7 @@ class ProductReviewsPage extends StatefulWidget {
 
   final Product product;
 
-  const ProductReviewsPage({Key? key, required this.product}) : super(key: key);
+  const ProductReviewsPage({super.key, required this.product});
 
   @override
   State<ProductReviewsPage> createState() => _ProductReviewsPageState();

--- a/tocopedia-flutter/lib/presentation/pages/features/review/view_review_page.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/review/view_review_page.dart
@@ -17,7 +17,7 @@ class ViewReviewPage extends StatefulWidget {
 
   final String reviewId;
 
-  const ViewReviewPage({Key? key, required this.reviewId}) : super(key: key);
+  const ViewReviewPage({super.key, required this.reviewId});
 
   @override
   State<ViewReviewPage> createState() => _ViewReviewPageState();
@@ -141,11 +141,10 @@ class ViewProductCard extends StatelessWidget {
   final String image;
 
   const ViewProductCard(
-      {Key? key,
+      {super.key,
       required this.productId,
       required this.name,
-      required this.image})
-      : super(key: key);
+      required this.image});
 
   @override
   Widget build(BuildContext context) {

--- a/tocopedia-flutter/lib/presentation/pages/features/review/widgets/history_review_tile.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/review/widgets/history_review_tile.dart
@@ -9,7 +9,7 @@ import 'package:tocopedia/presentation/pages/features/review/view_review_page.da
 class HistoryReviewTile extends StatelessWidget {
   final Review review;
 
-  const HistoryReviewTile({Key? key, required this.review}) : super(key: key);
+  const HistoryReviewTile({super.key, required this.review});
 
   @override
   Widget build(BuildContext context) {

--- a/tocopedia-flutter/lib/presentation/pages/features/review/widgets/pending_review_tile.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/review/widgets/pending_review_tile.dart
@@ -9,7 +9,7 @@ import 'package:tocopedia/presentation/pages/features/review/add_review_page.dar
 class PendingReviewTile extends StatelessWidget {
   final Review review;
 
-  const PendingReviewTile({Key? key, required this.review}) : super(key: key);
+  const PendingReviewTile({super.key, required this.review});
 
   @override
   Widget build(BuildContext context) {

--- a/tocopedia-flutter/lib/presentation/pages/features/review/widgets/product_review_tile.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/review/widgets/product_review_tile.dart
@@ -9,7 +9,7 @@ import 'package:tocopedia/presentation/pages/common_widgets/images/photos_horizo
 class ProductReviewTile extends StatefulWidget {
   final Review review;
 
-  const ProductReviewTile({Key? key, required this.review}) : super(key: key);
+  const ProductReviewTile({super.key, required this.review});
 
   @override
   State<ProductReviewTile> createState() => _ProductReviewTileState();

--- a/tocopedia-flutter/lib/presentation/pages/features/seller_order/seller_view_order_page.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/seller_order/seller_view_order_page.dart
@@ -8,7 +8,7 @@ import 'package:tocopedia/presentation/providers/order_item_provider.dart';
 import 'package:tocopedia/presentation/helper_variables/order_item_status_enum.dart';
 
 class SellerViewOrderPage extends StatefulWidget {
-  const SellerViewOrderPage({Key? key}) : super(key: key);
+  const SellerViewOrderPage({super.key});
 
   @override
   State<SellerViewOrderPage> createState() => _SellerViewOrderPageState();

--- a/tocopedia-flutter/lib/presentation/pages/features/seller_product/seller_add_product_page.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/seller_product/seller_add_product_page.dart
@@ -11,7 +11,7 @@ import 'package:tocopedia/presentation/providers/product_provider.dart';
 class SellerAddProductPage extends StatefulWidget {
   static const String routeName = "seller/products/add";
 
-  const SellerAddProductPage({Key? key}) : super(key: key);
+  const SellerAddProductPage({super.key});
 
   @override
   State<SellerAddProductPage> createState() => _SellerAddProductPageState();

--- a/tocopedia-flutter/lib/presentation/pages/features/seller_product/seller_edit_product_page.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/seller_product/seller_edit_product_page.dart
@@ -13,8 +13,7 @@ class SellerEditProductPage extends StatefulWidget {
   static const String routeName = "seller/products/edit";
   final Product product;
 
-  const SellerEditProductPage({Key? key, required this.product})
-      : super(key: key);
+  const SellerEditProductPage({super.key, required this.product});
 
   @override
   State<SellerEditProductPage> createState() => _SellerEditProductPageState();

--- a/tocopedia-flutter/lib/presentation/pages/features/seller_product/seller_view_all_products_page.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/seller_product/seller_view_all_products_page.dart
@@ -7,7 +7,7 @@ import 'package:tocopedia/presentation/providers/product_provider.dart';
 import 'package:tocopedia/presentation/pages/features/seller_product/widgets/product_list_tile.dart';
 
 class SellerViewAllProductsPage extends StatefulWidget {
-  const SellerViewAllProductsPage({Key? key}) : super(key: key);
+  const SellerViewAllProductsPage({super.key});
 
   @override
   State<SellerViewAllProductsPage> createState() =>

--- a/tocopedia-flutter/lib/presentation/pages/features/seller_product/widgets/category_dropdown.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/seller_product/widgets/category_dropdown.dart
@@ -5,8 +5,7 @@ import 'package:tocopedia/domains/entities/category.dart';
 import 'package:tocopedia/presentation/providers/category_provider.dart';
 
 class CategoryDropdown extends StatefulWidget {
-  const CategoryDropdown({Key? key, this.onChanged, this.initialCategory})
-      : super(key: key);
+  const CategoryDropdown({super.key, this.onChanged, this.initialCategory});
   final Function(Category? value)? onChanged;
   final Category? initialCategory;
 

--- a/tocopedia-flutter/lib/presentation/pages/features/seller_product/widgets/edit_product_action_buttons.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/seller_product/widgets/edit_product_action_buttons.dart
@@ -122,8 +122,7 @@ class EditProductActionButtons extends StatelessWidget {
 class ChangePriceBottomSheet extends StatefulWidget {
   final int initialPrice;
 
-  const ChangePriceBottomSheet({Key? key, required this.initialPrice})
-      : super(key: key);
+  const ChangePriceBottomSheet({super.key, required this.initialPrice});
 
   @override
   State<ChangePriceBottomSheet> createState() => _ChangePriceBottomSheetState();
@@ -190,8 +189,7 @@ class ChangeStockBottomSheet extends StatefulWidget {
   final int initialStock;
 
   const ChangeStockBottomSheet(
-      {Key? key, required this.initialActive, required this.initialStock})
-      : super(key: key);
+      {super.key, required this.initialActive, required this.initialStock});
 
   @override
   State<ChangeStockBottomSheet> createState() => _ChangeStockBottomSheetState();
@@ -300,8 +298,7 @@ class ShowMoreOptionsBottomSheet extends StatelessWidget {
   final void Function()? onView;
   final void Function()? onDelete;
 
-  const ShowMoreOptionsBottomSheet({Key? key, this.onView, this.onDelete})
-      : super(key: key);
+  const ShowMoreOptionsBottomSheet({super.key, this.onView, this.onDelete});
 
   @override
   Widget build(BuildContext context) {

--- a/tocopedia-flutter/lib/presentation/pages/features/seller_product/widgets/product_list_tile.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/seller_product/widgets/product_list_tile.dart
@@ -9,7 +9,7 @@ import 'package:tocopedia/presentation/pages/features/seller_product/widgets/edi
 class ProductListTile extends StatelessWidget {
   final Product product;
 
-  const ProductListTile({Key? key, required this.product}) : super(key: key);
+  const ProductListTile({super.key, required this.product});
 
   @override
   Widget build(BuildContext context) {

--- a/tocopedia-flutter/lib/presentation/pages/features/transaction/transaction_page.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/transaction/transaction_page.dart
@@ -11,7 +11,7 @@ import 'package:tocopedia/presentation/helper_variables/provider_state.dart';
 class TransactionPage extends StatefulWidget {
   static const String routeName = "/transactions";
 
-  const TransactionPage({Key? key}) : super(key: key);
+  const TransactionPage({super.key});
 
   @override
   State<TransactionPage> createState() => _TransactionPageState();

--- a/tocopedia-flutter/lib/presentation/pages/features/transaction/view_order_item_page.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/transaction/view_order_item_page.dart
@@ -17,8 +17,7 @@ class ViewOrderItemPage extends StatefulWidget {
 
   final String orderItemId;
 
-  const ViewOrderItemPage({Key? key, required this.orderItemId})
-      : super(key: key);
+  const ViewOrderItemPage({super.key, required this.orderItemId});
 
   @override
   State<ViewOrderItemPage> createState() => _ViewOrderItemPageState();

--- a/tocopedia-flutter/lib/presentation/pages/features/transaction/widgets/order_item_action_button.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/transaction/widgets/order_item_action_button.dart
@@ -154,7 +154,7 @@ class OrderItemActionButton extends StatelessWidget {
 }
 
 class InputAirwayBillDialog extends StatefulWidget {
-  const InputAirwayBillDialog({Key? key}) : super(key: key);
+  const InputAirwayBillDialog({super.key});
 
   @override
   State<InputAirwayBillDialog> createState() => _InputAirwayBillDialogState();

--- a/tocopedia-flutter/lib/presentation/pages/features/transaction/widgets/single_order_item_card.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/transaction/widgets/single_order_item_card.dart
@@ -10,8 +10,7 @@ import 'package:tocopedia/presentation/pages/common_widgets/status_card.dart';
 class SingleOrderItemCard extends StatelessWidget {
   final OrderItem orderItem;
 
-  const SingleOrderItemCard({Key? key, required this.orderItem})
-      : super(key: key);
+  const SingleOrderItemCard({super.key, required this.orderItem});
 
   @override
   Widget build(BuildContext context) {

--- a/tocopedia-flutter/lib/presentation/pages/features/transaction/widgets/single_order_item_detail_card.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/transaction/widgets/single_order_item_detail_card.dart
@@ -11,8 +11,7 @@ import 'package:tocopedia/presentation/providers/local_settings_provider.dart';
 class SingleOrderItemDetailCard extends StatelessWidget {
   final OrderItemDetail orderItemDetail;
 
-  const SingleOrderItemDetailCard({Key? key, required this.orderItemDetail})
-      : super(key: key);
+  const SingleOrderItemDetailCard({super.key, required this.orderItemDetail});
 
   Future<void> addToCart(BuildContext context) async {
     await handleFutureFunction(

--- a/tocopedia-flutter/lib/presentation/pages/features/transaction/widgets/waiting_payment_card.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/transaction/widgets/waiting_payment_card.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:tocopedia/presentation/pages/features/order/view_all_orders_page.dart';
 
 class WaitingPaymentCard extends StatelessWidget {
-  const WaitingPaymentCard({Key? key}) : super(key: key);
+  const WaitingPaymentCard({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/tocopedia-flutter/lib/presentation/pages/features/user/edit_user_page.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/user/edit_user_page.dart
@@ -7,7 +7,7 @@ import 'package:tocopedia/presentation/providers/user_provider.dart';
 class EditUserPage extends StatefulWidget {
   static const String routeName = '/users/edit';
 
-  const EditUserPage({Key? key}) : super(key: key);
+  const EditUserPage({super.key});
 
   @override
   State<EditUserPage> createState() => _EditUserPageState();

--- a/tocopedia-flutter/lib/presentation/pages/features/user/user_page.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/user/user_page.dart
@@ -10,7 +10,7 @@ import 'package:intl/intl.dart';
 class UserPage extends StatelessWidget {
   static const String routeName = "/users";
 
-  const UserPage({Key? key}) : super(key: key);
+  const UserPage({super.key});
 
   Future<void> logout(BuildContext context) async {
     await handleFutureFunction(

--- a/tocopedia-flutter/lib/presentation/pages/features/wishlist/wishlist_page.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/wishlist/wishlist_page.dart
@@ -9,7 +9,7 @@ import 'package:tocopedia/presentation/pages/features/product/widgets/single_pro
 import 'package:tocopedia/presentation/providers/wishlist_provider.dart';
 
 class WishListPage extends StatefulWidget {
-  const WishListPage({Key? key}) : super(key: key);
+  const WishListPage({super.key});
 
   @override
   State<WishListPage> createState() => _WishListPageState();


### PR DESCRIPTION
## Summary
- Convert `{Key? key} : super(key: key)` to `{super.key}` across 52 widget files
- Also converts `validator`, `onSaved`, `initialValue` to super parameters in `CheckboxFormField`
- Resolves 58 `use_super_parameters` info-level lint issues

## Test plan
- [x] `dart fix --dry-run --code=use_super_parameters` shows 0 remaining issues
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)