### PR TITLE
fix: replace double underscores with single underscore

### DIFF
--- a/tocopedia-flutter/lib/main.dart
+++ b/tocopedia-flutter/lib/main.dart
@@ -52,7 +52,7 @@ class MyApp extends StatelessWidget {
         ),
         ChangeNotifierProxyProvider<UserProvider, ProductProvider>(
           create: (_) => di.locator<ProductProvider>(),
-          update: (_, value, __) =>
+          update: (_, value, _) =>
               di.locator<ProductProvider>(param1: value.user?.token),
         ),
         ChangeNotifierProxyProvider<UserProvider, CartProvider>(
@@ -69,17 +69,17 @@ class MyApp extends StatelessWidget {
         ),
         ChangeNotifierProxyProvider<UserProvider, OrderProvider>(
           create: (_) => di.locator<OrderProvider>(),
-          update: (_, value, __) =>
+          update: (_, value, _) =>
               di.locator<OrderProvider>(param1: value.user?.token),
         ),
         ChangeNotifierProxyProvider<UserProvider, WishlistProvider>(
           create: (_) => di.locator<WishlistProvider>(),
-          update: (_, value, __) =>
+          update: (_, value, _) =>
               di.locator<WishlistProvider>(param1: value.user?.token),
         ),
         ChangeNotifierProxyProvider<UserProvider, OrderItemProvider>(
           create: (_) => di.locator<OrderItemProvider>(),
-          update: (_, value, __) =>
+          update: (_, value, _) =>
               di.locator<OrderItemProvider>(param1: value.user?.token),
         ),
         ChangeNotifierProxyProvider<UserProvider, AddressProvider>(

--- a/tocopedia-flutter/lib/presentation/pages/common_widgets/cart_button.dart
+++ b/tocopedia-flutter/lib/presentation/pages/common_widgets/cart_button.dart
@@ -11,7 +11,7 @@ class CartButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return IconButton(
-      icon: Consumer<CartProvider>(builder: (_, cartProvider, __) {
+      icon: Consumer<CartProvider>(builder: (_, cartProvider, _) {
         return Badge.count(
             count: cartProvider.totalItemCount,
             child: const Icon(Icons.shopping_cart_outlined, size: 25));

--- a/tocopedia-flutter/lib/presentation/pages/common_widgets/images/images_gallery_page.dart
+++ b/tocopedia-flutter/lib/presentation/pages/common_widgets/images/images_gallery_page.dart
@@ -109,7 +109,7 @@ class _ImagesGalleryPageState extends State<ImagesGalleryPage> {
                           padding: const EdgeInsets.symmetric(vertical: 8),
                           scrollDirection: Axis.horizontal,
                           itemCount: images.length,
-                          separatorBuilder: (_, __) => const SizedBox(width: 8),
+                          separatorBuilder: (_, _) => const SizedBox(width: 8),
                           itemBuilder: (context, index) {
                             return GestureDetector(
                               onTap: () => updateIndex(index),
@@ -134,7 +134,7 @@ class _ImagesGalleryPageState extends State<ImagesGalleryPage> {
                                   fit: BoxFit.cover,
                                   height: size,
                                   width: size,
-                                  progressIndicatorBuilder: (_, __, downloadProgress) => Center(
+                                  progressIndicatorBuilder: (_, _, downloadProgress) => Center(
                                       child: CircularProgressIndicator(
                                           value: downloadProgress.progress)),
                                   errorWidget: (context, url, error) => const Icon(Icons.error),

--- a/tocopedia-flutter/lib/presentation/pages/common_widgets/images/photos_horizontal_listview.dart
+++ b/tocopedia-flutter/lib/presentation/pages/common_widgets/images/photos_horizontal_listview.dart
@@ -48,7 +48,7 @@ class PhotosHorizontalListView extends StatelessWidget {
         padding: const EdgeInsets.symmetric(vertical: 8),
         scrollDirection: Axis.horizontal,
         itemCount: images.length,
-        separatorBuilder: (_, __) => const SizedBox(width: 8),
+        separatorBuilder: (_, _) => const SizedBox(width: 8),
         itemBuilder: (context, index) {
           return Center(
             child: GestureDetector(
@@ -70,7 +70,7 @@ class PhotosHorizontalListView extends StatelessWidget {
                   fit: BoxFit.cover,
                   height: size,
                   width: size,
-                  progressIndicatorBuilder: (_, __, downloadProgress) => Center(
+                  progressIndicatorBuilder: (_, _, downloadProgress) => Center(
                       child: CircularProgressIndicator(
                           value: downloadProgress.progress)),
                   errorWidget: (context, url, error) => const Icon(Icons.error),

--- a/tocopedia-flutter/lib/presentation/pages/common_widgets/images/pick_image_tile.dart
+++ b/tocopedia-flutter/lib/presentation/pages/common_widgets/images/pick_image_tile.dart
@@ -48,7 +48,7 @@ class PickImageTile extends StatelessWidget {
         imageWidget = CachedNetworkImage(
           imageUrl: pickedImage,
           fit: BoxFit.cover,
-          progressIndicatorBuilder: (_, __, downloadProgress) => Center(
+          progressIndicatorBuilder: (_, _, downloadProgress) => Center(
               child:
                   CircularProgressIndicator(value: downloadProgress.progress)),
           errorWidget: (context, url, error) => const Icon(Icons.error),

--- a/tocopedia-flutter/lib/presentation/pages/features/cart/widgets/cart_item_detail_tile.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/cart/widgets/cart_item_detail_tile.dart
@@ -177,7 +177,7 @@ class _CartItemDetailTileState extends State<CartItemDetailTile> {
                         child: CachedNetworkImage(
                           imageUrl: product.images![0],
                           fit: BoxFit.cover,
-                          progressIndicatorBuilder: (_, __, downloadProgress) =>
+                          progressIndicatorBuilder: (_, _, downloadProgress) =>
                               Center(
                                   child: CircularProgressIndicator(
                                       value: downloadProgress.progress)),

--- a/tocopedia-flutter/lib/presentation/pages/features/cart/widgets/cart_item_tile.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/cart/widgets/cart_item_tile.dart
@@ -59,7 +59,7 @@ class _CartItemTileState extends State<CartItemTile> {
       checked = value;
     });
     _shopCheckboxNotifier.setValue(value);
-    childrenValues.updateAll((_, __) => value);
+    childrenValues.updateAll((_, _) => value);
 
     if (value) {
       await Provider.of<CartProvider>(context, listen: false)

--- a/tocopedia-flutter/lib/presentation/pages/features/cart/widgets/checkout_item_detail_tile.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/cart/widgets/checkout_item_detail_tile.dart
@@ -29,7 +29,7 @@ class CheckoutItemDetailTile extends StatelessWidget {
             child: CachedNetworkImage(
               imageUrl: product!.images![0],
               fit: BoxFit.cover,
-              progressIndicatorBuilder: (_, __, downloadProgress) => Center(
+              progressIndicatorBuilder: (_, _, downloadProgress) => Center(
                   child: CircularProgressIndicator(
                       value: downloadProgress.progress)),
               errorWidget: (context, url, error) => const Icon(Icons.error),

--- a/tocopedia-flutter/lib/presentation/pages/features/home/widgets/category_button.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/home/widgets/category_button.dart
@@ -24,7 +24,7 @@ class CategoryButton extends StatelessWidget {
             imageUrl: category.image!,
             height: 30,
             width: 30,
-            progressIndicatorBuilder: (_, __, downloadProgress) => Center(
+            progressIndicatorBuilder: (_, _, downloadProgress) => Center(
                 child: CircularProgressIndicator(
                     value: downloadProgress.progress)),
             errorWidget: (context, url, error) => const Icon(Icons.error),

--- a/tocopedia-flutter/lib/presentation/pages/features/product/widgets/product_image_carousel.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/product/widgets/product_image_carousel.dart
@@ -31,7 +31,7 @@ class _ProductImagePreviewState extends State<ProductImageCarousel> {
                       images: widget.images, startingIndex: index)),
               child: CachedNetworkImage(
                 imageUrl: widget.images[index],
-                progressIndicatorBuilder: (_, __, downloadProgress) => Center(
+                progressIndicatorBuilder: (_, _, downloadProgress) => Center(
                     child: CircularProgressIndicator(
                         value: downloadProgress.progress)),
                 errorWidget: (context, url, error) => const Icon(Icons.error),

--- a/tocopedia-flutter/lib/presentation/pages/features/product/widgets/single_product_card.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/product/widgets/single_product_card.dart
@@ -30,7 +30,7 @@ class SingleProductCard extends StatelessWidget {
               child: CachedNetworkImage(
                 imageUrl: product.images![0],
                 fit: BoxFit.cover,
-                progressIndicatorBuilder: (_, __, downloadProgress) => Center(
+                progressIndicatorBuilder: (_, _, downloadProgress) => Center(
                     child: CircularProgressIndicator(
                         value: downloadProgress.progress)),
                 errorWidget: (context, url, error) => const Icon(Icons.error),

--- a/tocopedia-flutter/lib/presentation/pages/features/review/add_review_page.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/review/add_review_page.dart
@@ -100,7 +100,7 @@ class _AddReviewPageState extends State<AddReviewPage> {
                             imageUrl: widget.review.productImage!,
                             width: 50,
                             height: 50,
-                            progressIndicatorBuilder: (_, __, downloadProgress) => Center(
+                            progressIndicatorBuilder: (_, _, downloadProgress) => Center(
                                 child: CircularProgressIndicator(
                                     value: downloadProgress.progress)),
                             errorWidget: (context, url, error) => const Icon(Icons.error),
@@ -124,7 +124,7 @@ class _AddReviewPageState extends State<AddReviewPage> {
                           initialRating: widget.initialRating.toDouble(),
                           glow: false,
                           itemSize: 60,
-                          itemBuilder: (_, __) => const Icon(Icons.star_rounded,
+                          itemBuilder: (_, _) => const Icon(Icons.star_rounded,
                               color: CustomColors.starColor),
                           onRatingUpdate: (double value) =>
                               setState(() => _rating = value.toInt()),

--- a/tocopedia-flutter/lib/presentation/pages/features/review/edit_review_page.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/review/edit_review_page.dart
@@ -109,7 +109,7 @@ class _EditReviewPageState extends State<EditReviewPage> {
                             width: 50,
                             height: 50,
                             progressIndicatorBuilder:
-                                (_, __, downloadProgress) => Center(
+                                (_, _, downloadProgress) => Center(
                                     child: CircularProgressIndicator(
                                         value: downloadProgress.progress)),
                             errorWidget: (context, url, error) =>
@@ -134,7 +134,7 @@ class _EditReviewPageState extends State<EditReviewPage> {
                           initialRating: widget.review.rating!.toDouble(),
                           glow: false,
                           itemSize: 60,
-                          itemBuilder: (_, __) => const Icon(Icons.star_rounded,
+                          itemBuilder: (_, _) => const Icon(Icons.star_rounded,
                               color: CustomColors.starColor),
                           onRatingUpdate: (double value) =>
                               setState(() => _rating = value.toInt()),

--- a/tocopedia-flutter/lib/presentation/pages/features/review/view_review_page.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/review/view_review_page.dart
@@ -167,7 +167,7 @@ class ViewProductCard extends StatelessWidget {
               imageUrl: image,
               width: 50,
               height: 50,
-              progressIndicatorBuilder: (_, __, downloadProgress) => Center(
+              progressIndicatorBuilder: (_, _, downloadProgress) => Center(
                   child: CircularProgressIndicator(
                       value: downloadProgress.progress)),
               errorWidget: (context, url, error) => const Icon(Icons.error),

--- a/tocopedia-flutter/lib/presentation/pages/features/review/widgets/history_review_tile.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/review/widgets/history_review_tile.dart
@@ -34,7 +34,7 @@ class HistoryReviewTile extends StatelessWidget {
                   itemSize: 20,
                   ignoreGestures: true,
                   initialRating: review.rating?.toDouble() ?? 0,
-                  itemBuilder: (_, __) => const Icon(Icons.star_rounded,
+                  itemBuilder: (_, _) => const Icon(Icons.star_rounded,
                       color: CustomColors.starColor),
                   onRatingUpdate: (_) {},
                 ),

--- a/tocopedia-flutter/lib/presentation/pages/features/review/widgets/pending_review_tile.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/review/widgets/pending_review_tile.dart
@@ -39,7 +39,7 @@ class PendingReviewTile extends StatelessWidget {
                 child: CachedNetworkImage(
                   imageUrl: review.productImage!,
                   fit: BoxFit.cover,
-                  progressIndicatorBuilder: (_, __, downloadProgress) => Center(
+                  progressIndicatorBuilder: (_, _, downloadProgress) => Center(
                       child: CircularProgressIndicator(
                           value: downloadProgress.progress)),
                   errorWidget: (context, url, error) => const Icon(Icons.error),
@@ -71,7 +71,7 @@ class PendingReviewTile extends StatelessWidget {
                         ),
                       ),
                       glow: false,
-                      itemBuilder: (_, __) => const Icon(Icons.star_rounded,
+                      itemBuilder: (_, _) => const Icon(Icons.star_rounded,
                           color: CustomColors.starColor),
                     ),
                   ],

--- a/tocopedia-flutter/lib/presentation/pages/features/review/widgets/product_review_tile.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/review/widgets/product_review_tile.dart
@@ -48,7 +48,7 @@ class _ProductReviewTileState extends State<ProductReviewTile> {
               itemSize: 20,
               ignoreGestures: true,
               initialRating: widget.review.rating!.toDouble(),
-              itemBuilder: (_, __) =>
+              itemBuilder: (_, _) =>
                   const Icon(Icons.star_rounded, color: CustomColors.starColor),
               onRatingUpdate: (_) {},
             ),

--- a/tocopedia-flutter/lib/presentation/pages/features/seller_product/widgets/category_dropdown.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/seller_product/widgets/category_dropdown.dart
@@ -63,7 +63,7 @@ class _CategoryDropdownState extends State<CategoryDropdown> {
                 imageUrl: value.image!,
                 height: 30,
                 width: 30,
-                progressIndicatorBuilder: (_, __, downloadProgress) => Center(
+                progressIndicatorBuilder: (_, _, downloadProgress) => Center(
                     child: CircularProgressIndicator(
                         value: downloadProgress.progress)),
                 errorWidget: (context, url, error) => const Icon(Icons.error),

--- a/tocopedia-flutter/lib/presentation/pages/features/seller_product/widgets/product_list_tile.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/seller_product/widgets/product_list_tile.dart
@@ -38,7 +38,7 @@ class ProductListTile extends StatelessWidget {
                   child: CachedNetworkImage(
                     imageUrl: product.images![0],
                     fit: BoxFit.cover,
-                    progressIndicatorBuilder: (_, __, downloadProgress) =>
+                    progressIndicatorBuilder: (_, _, downloadProgress) =>
                         Center(
                             child: CircularProgressIndicator(
                                 value: downloadProgress.progress)),

--- a/tocopedia-flutter/lib/presentation/pages/features/transaction/widgets/single_order_item_card.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/transaction/widgets/single_order_item_card.dart
@@ -56,7 +56,7 @@ class SingleOrderItemCard extends StatelessWidget {
                       width: 50,
                       height: 50,
                       fit: BoxFit.cover,
-                      progressIndicatorBuilder: (_, __, downloadProgress) =>
+                      progressIndicatorBuilder: (_, _, downloadProgress) =>
                           Center(
                               child: CircularProgressIndicator(
                                   value: downloadProgress.progress)),

--- a/tocopedia-flutter/lib/presentation/pages/features/transaction/widgets/single_order_item_detail_card.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/transaction/widgets/single_order_item_detail_card.dart
@@ -55,7 +55,7 @@ class SingleOrderItemDetailCard extends StatelessWidget {
                       width: 50,
                       height: 50,
                       fit: BoxFit.cover,
-                      progressIndicatorBuilder: (_, __, downloadProgress) =>
+                      progressIndicatorBuilder: (_, _, downloadProgress) =>
                           Center(
                               child: CircularProgressIndicator(
                                   value: downloadProgress.progress)),


### PR DESCRIPTION
## Summary
- Replace `__` with `_` for unused parameter placeholders across 21 files
- Dart 3+ only needs a single `_` to ignore a parameter
- Resolves 29 `unnecessary_underscores` info-level lint issues

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)