### PR TITLE
fix: replace deprecated withOpacity and value usage

### DIFF
--- a/tocopedia-flutter/lib/presentation/pages/common_widgets/status_card.dart
+++ b/tocopedia-flutter/lib/presentation/pages/common_widgets/status_card.dart
@@ -14,7 +14,7 @@ class StatusCard extends StatelessWidget {
       padding: const EdgeInsets.all(4),
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(5),
-        color: color.withOpacity(0.2),
+        color: color.withValues(alpha: 0.2),
       ),
       child: Text(
         text.toTitleCase(),

--- a/tocopedia-flutter/lib/presentation/pages/features/address/widgets/single_address_card.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/address/widgets/single_address_card.dart
@@ -114,12 +114,12 @@ class SingleAddressCard extends StatelessWidget {
         side: BorderSide(
           color: isDefault
               ? theme.colorScheme.primary
-              : theme.colorScheme.outline.withOpacity(0.5),
+              : theme.colorScheme.outline.withValues(alpha: 0.5),
         ),
         borderRadius: const BorderRadius.all(Radius.circular(12)),
       ),
       color: isDefault
-          ? theme.colorScheme.secondaryContainer.withOpacity(.25)
+          ? theme.colorScheme.secondaryContainer.withValues(alpha: .25)
           : null,
       child: Column(
         children: [

--- a/tocopedia-flutter/lib/presentation/pages/features/cart/cart_page.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/cart/cart_page.dart
@@ -91,7 +91,7 @@ class _CartPageState extends State<CartPage> {
                 color: theme.scaffoldBackgroundColor,
                 boxShadow: [
                   BoxShadow(
-                    color: Colors.grey.withOpacity(1),
+                    color: Colors.grey.withValues(alpha: 1),
                     spreadRadius: 2,
                     blurRadius: 2,
                     offset: const Offset(0, 2),

--- a/tocopedia-flutter/lib/presentation/pages/features/cart/checkout_page.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/cart/checkout_page.dart
@@ -125,7 +125,7 @@ class _CheckoutPageState extends State<CheckoutPage> {
               color: theme.scaffoldBackgroundColor,
               boxShadow: [
                 BoxShadow(
-                  color: Colors.grey.withOpacity(1),
+                  color: Colors.grey.withValues(alpha: 1),
                   spreadRadius: 2,
                   blurRadius: 2,
                   offset: const Offset(0, 2),

--- a/tocopedia-flutter/lib/presentation/pages/features/cart/widgets/address_selection_card.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/cart/widgets/address_selection_card.dart
@@ -27,12 +27,12 @@ class AddressSelectionCard extends StatelessWidget {
           side: BorderSide(
             color: isSelected
                 ? theme.colorScheme.primary
-                : theme.colorScheme.outline.withOpacity(0.5),
+                : theme.colorScheme.outline.withValues(alpha: 0.5),
           ),
           borderRadius: const BorderRadius.all(Radius.circular(12)),
         ),
         color: isSelected
-            ? theme.colorScheme.secondaryContainer.withOpacity(.25)
+            ? theme.colorScheme.secondaryContainer.withValues(alpha: .25)
             : null,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,

--- a/tocopedia-flutter/lib/presentation/pages/features/product/widgets/add_to_cart_button.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/product/widgets/add_to_cart_button.dart
@@ -75,7 +75,7 @@ class AddToCartButton extends StatelessWidget {
           color: theme.scaffoldBackgroundColor,
           boxShadow: [
             BoxShadow(
-              color: Colors.grey.withOpacity(0.5),
+              color: Colors.grey.withValues(alpha: 0.5),
               spreadRadius: 2,
               blurRadius: 2,
               offset: const Offset(0, 2),

--- a/tocopedia-flutter/lib/presentation/pages/features/review/view_review_page.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/review/view_review_page.dart
@@ -156,7 +156,7 @@ class ViewProductCard extends StatelessWidget {
         elevation: 0,
         shape: RoundedRectangleBorder(
           side: BorderSide(
-            color: Theme.of(context).colorScheme.outline.withOpacity(0.5),
+            color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.5),
           ),
           borderRadius: const BorderRadius.all(Radius.circular(12)),
         ),

--- a/tocopedia-flutter/lib/presentation/pages/features/seller_product/widgets/category_dropdown.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/seller_product/widgets/category_dropdown.dart
@@ -37,7 +37,7 @@ class _CategoryDropdownState extends State<CategoryDropdown> {
           ?.firstWhere((element) => element.id == widget.initialCategory!.id);
     }
     return DropdownButtonFormField<Category>(
-      value: dropdownValue,
+      initialValue: dropdownValue,
       validator: (value) {
         if (value == null) return "Select category";
         return null;

--- a/tocopedia-flutter/lib/presentation/pages/features/transaction/widgets/order_item_action_button.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/transaction/widgets/order_item_action_button.dart
@@ -84,7 +84,7 @@ class OrderItemActionButton extends StatelessWidget {
         color: Theme.of(context).scaffoldBackgroundColor,
         boxShadow: [
           BoxShadow(
-            color: Colors.grey.withOpacity(1),
+            color: Colors.grey.withValues(alpha: 1),
             spreadRadius: 2,
             blurRadius: 2,
             offset: const Offset(0, 2),

--- a/tocopedia-flutter/lib/presentation/pages/features/transaction/widgets/single_order_item_detail_card.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/transaction/widgets/single_order_item_detail_card.dart
@@ -36,7 +36,7 @@ class SingleOrderItemDetailCard extends StatelessWidget {
         elevation: 0,
         shape: RoundedRectangleBorder(
           side: BorderSide(
-            color: Theme.of(context).colorScheme.outline.withOpacity(0.5),
+            color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.5),
           ),
           borderRadius: const BorderRadius.all(Radius.circular(12)),
         ),


### PR DESCRIPTION
## Summary
- Replace `.withOpacity()` with `.withValues(alpha:)` in 9 widget files to fix `deprecated_member_use` lint issues
- Replace deprecated `value:` parameter with `initialValue:` in `category_dropdown.dart`

## Test plan
- [x] CI `flutter analyze --no-fatal-infos` passes (no `deprecated_member_use` issues remain)
- [x] `flutter build web` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)