### PR TITLE
fix: update Flutter web loader API to remove deprecated calls

### DIFF
--- a/tocopedia-flutter/web/index.html
+++ b/tocopedia-flutter/web/index.html
@@ -30,10 +30,6 @@
   <title>tocopedia</title>
   <link rel="manifest" href="manifest.json">
 
-  <script>
-    // The value below is injected by flutter build, do not touch.
-    var serviceWorkerVersion = null;
-  </script>
   <!-- This script adds the flutter initialization JS code -->
   <script src="flutter.js" defer=""></script>
   <!-- Preload main.dart.js so it downloads in parallel with flutter.js -->
@@ -129,10 +125,7 @@
   </picture>    
   <script>
     window.addEventListener('load', function(ev) {
-      _flutter.loader.loadEntrypoint({
-        serviceWorker: {
-          serviceWorkerVersion: serviceWorkerVersion,
-        },
+      _flutter.loader.load({
         onEntrypointLoaded: function(engineInitializer) {
           engineInitializer.initializeEngine().then(function(appRunner) {
             appRunner.runApp();


### PR DESCRIPTION
## Summary
- Remove deprecated `serviceWorkerVersion` script block from `index.html` (see flutter/flutter#156910)
- Replace deprecated `_flutter.loader.loadEntrypoint` with `_flutter.loader.load`

## Test plan
- [x] `flutter build web` completes with no deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)