### PR TITLE
fix: resolve remaining info-level lint issues

### DIFF
--- a/tocopedia-flutter/lib/common/env_variables.dart
+++ b/tocopedia-flutter/lib/common/env_variables.dart
@@ -1,2 +1,2 @@
-const BASE_URL = String.fromEnvironment('BASE_URL',
+const baseUrl = String.fromEnvironment('BASE_URL',
     defaultValue: "http://localhost:3000");

--- a/tocopedia-flutter/lib/data/data_sources/address_remote_data_source.dart
+++ b/tocopedia-flutter/lib/data/data_sources/address_remote_data_source.dart
@@ -56,7 +56,7 @@ class AddressRemoteDataSourceImpl implements AddressRemoteDataSource {
       "receiver_phone": receiverPhone,
     }..removeWhere((key, value) => value == null || value.toString().isEmpty));
 
-    final url = Uri.parse(BASE_URL).replace(path: '/addresses');
+    final url = Uri.parse(baseUrl).replace(path: '/addresses');
 
     final response = await client
         .post(
@@ -93,7 +93,7 @@ class AddressRemoteDataSourceImpl implements AddressRemoteDataSource {
       }..removeWhere(
           (key, value) => value == null || value.toString().isEmpty));
 
-      final url = Uri.parse(BASE_URL).replace(path: '/addresses/$addressId');
+      final url = Uri.parse(baseUrl).replace(path: '/addresses/$addressId');
 
       final response = await client
           .patch(
@@ -121,7 +121,7 @@ class AddressRemoteDataSourceImpl implements AddressRemoteDataSource {
   @override
   Future<AddressModel> deleteAddress(String token, String addressId) async {
     try {
-      final url = Uri.parse(BASE_URL).replace(path: '/addresses/$addressId');
+      final url = Uri.parse(baseUrl).replace(path: '/addresses/$addressId');
 
       final response = await client
           .delete(
@@ -148,7 +148,7 @@ class AddressRemoteDataSourceImpl implements AddressRemoteDataSource {
   @override
   Future<AddressModel> getAddress(String token, String addressId) async {
     try {
-      final url = Uri.parse(BASE_URL).replace(path: '/addresses/$addressId');
+      final url = Uri.parse(baseUrl).replace(path: '/addresses/$addressId');
 
       final response = await client
           .get(
@@ -175,7 +175,7 @@ class AddressRemoteDataSourceImpl implements AddressRemoteDataSource {
   @override
   Future<List<AddressModel>> getUserAddresses(String token) async {
     try {
-      final url = Uri.parse(BASE_URL).replace(path: '/addresses');
+      final url = Uri.parse(baseUrl).replace(path: '/addresses');
 
       final response = await client
           .get(

--- a/tocopedia-flutter/lib/data/data_sources/cart_remote_data_source.dart
+++ b/tocopedia-flutter/lib/data/data_sources/cart_remote_data_source.dart
@@ -35,7 +35,7 @@ class CartRemoteDataSourceImpl implements CartRemoteDataSource {
   @override
   Future<CartModel> getCart(String token) async {
     try {
-      final url = Uri.parse(BASE_URL).replace(path: '/cart');
+      final url = Uri.parse(baseUrl).replace(path: '/cart');
 
       final response = await client
           .get(
@@ -61,7 +61,7 @@ class CartRemoteDataSourceImpl implements CartRemoteDataSource {
   @override
   Future<CartModel> clearCart(String token) async {
     try {
-      final url = Uri.parse(BASE_URL).replace(path: '/cart/clear');
+      final url = Uri.parse(baseUrl).replace(path: '/cart/clear');
 
       final response = await client
           .patch(
@@ -88,7 +88,7 @@ class CartRemoteDataSourceImpl implements CartRemoteDataSource {
   @override
   Future<CartModel> addToCart(String token, String productId) async {
     try {
-      final url = Uri.parse(BASE_URL).replace(path: '/cart/add/$productId');
+      final url = Uri.parse(baseUrl).replace(path: '/cart/add/$productId');
 
       final response = await client
           .patch(
@@ -114,7 +114,7 @@ class CartRemoteDataSourceImpl implements CartRemoteDataSource {
   @override
   Future<CartModel> removeFromCart(String token, String productId) async {
     try {
-      final url = Uri.parse(BASE_URL).replace(path: '/cart/remove/$productId');
+      final url = Uri.parse(baseUrl).replace(path: '/cart/remove/$productId');
 
       final response = await client
           .patch(
@@ -140,7 +140,7 @@ class CartRemoteDataSourceImpl implements CartRemoteDataSource {
   @override
   Future<CartModel> selectCartItem(String token, String productId) async {
     try {
-      final url = Uri.parse(BASE_URL).replace(path: '/cart/select/$productId');
+      final url = Uri.parse(baseUrl).replace(path: '/cart/select/$productId');
 
       final response = await client
           .patch(
@@ -167,7 +167,7 @@ class CartRemoteDataSourceImpl implements CartRemoteDataSource {
   Future<CartModel> selectSeller(String token, String sellerId) async {
     try {
       final url =
-          Uri.parse(BASE_URL).replace(path: '/cart/select/seller/$sellerId');
+          Uri.parse(baseUrl).replace(path: '/cart/select/seller/$sellerId');
       final response = await client
           .patch(
             url,
@@ -193,7 +193,7 @@ class CartRemoteDataSourceImpl implements CartRemoteDataSource {
   Future<CartModel> unSelectCartItem(String token, String productId) async {
     try {
       final url =
-          Uri.parse(BASE_URL).replace(path: '/cart/unselect/$productId');
+          Uri.parse(baseUrl).replace(path: '/cart/unselect/$productId');
 
       final response = await client
           .patch(
@@ -220,7 +220,7 @@ class CartRemoteDataSourceImpl implements CartRemoteDataSource {
   Future<CartModel> unselectSeller(String token, String sellerId) async {
     try {
       final url =
-          Uri.parse(BASE_URL).replace(path: '/cart/unselect/seller/$sellerId');
+          Uri.parse(baseUrl).replace(path: '/cart/unselect/seller/$sellerId');
 
       final response = await client
           .patch(
@@ -247,7 +247,7 @@ class CartRemoteDataSourceImpl implements CartRemoteDataSource {
   Future<CartModel> updateCart(
       String token, String productId, int quantity) async {
     try {
-      final url = Uri.parse(BASE_URL).replace(path: '/cart/update/$productId');
+      final url = Uri.parse(baseUrl).replace(path: '/cart/update/$productId');
 
       final response = await client
           .patch(

--- a/tocopedia-flutter/lib/data/data_sources/category_remote_data_source.dart
+++ b/tocopedia-flutter/lib/data/data_sources/category_remote_data_source.dart
@@ -21,7 +21,7 @@ class CategoryRemoteDataSourceImpl implements CategoryRemoteDataSource {
   @override
   Future<List<CategoryModel>> getAllCategories() async {
     try {
-      final url = Uri.parse(BASE_URL).replace(path: '/categories');
+      final url = Uri.parse(baseUrl).replace(path: '/categories');
 
       final response = await client
           .get(
@@ -47,7 +47,7 @@ class CategoryRemoteDataSourceImpl implements CategoryRemoteDataSource {
   @override
   Future<CategoryModel> getCategory(String categoryId) async {
     try {
-      final url = Uri.parse(BASE_URL).replace(path: '/categories/$categoryId');
+      final url = Uri.parse(baseUrl).replace(path: '/categories/$categoryId');
 
       final response = await client
           .get(

--- a/tocopedia-flutter/lib/data/data_sources/order_item_remote_data_source.dart
+++ b/tocopedia-flutter/lib/data/data_sources/order_item_remote_data_source.dart
@@ -32,7 +32,7 @@ class OrderItemRemoteDataSourceImpl implements OrderItemRemoteDataSource {
   @override
   Future<List<OrderItemModel>> getBuyerOrderItems(String token) async {
     try {
-      final url = Uri.parse(BASE_URL).replace(path: '/order-items/buyer');
+      final url = Uri.parse(baseUrl).replace(path: '/order-items/buyer');
 
       final response = await client
           .get(
@@ -59,7 +59,7 @@ class OrderItemRemoteDataSourceImpl implements OrderItemRemoteDataSource {
   @override
   Future<List<OrderItemModel>> getSellerOrderItems(String token) async {
     try {
-      final url = Uri.parse(BASE_URL).replace(path: '/order-items/seller');
+      final url = Uri.parse(baseUrl).replace(path: '/order-items/seller');
 
       final response = await client
           .get(
@@ -87,7 +87,7 @@ class OrderItemRemoteDataSourceImpl implements OrderItemRemoteDataSource {
   Future<OrderItemModel> getOrderItem(String token, String orderItemId) async {
     try {
       final url =
-          Uri.parse(BASE_URL).replace(path: '/order-items/$orderItemId');
+          Uri.parse(baseUrl).replace(path: '/order-items/$orderItemId');
 
       final response = await client
           .get(
@@ -115,7 +115,7 @@ class OrderItemRemoteDataSourceImpl implements OrderItemRemoteDataSource {
       String token, String orderItemId) async {
     try {
       final url =
-          Uri.parse(BASE_URL).replace(path: '/order-items/$orderItemId/cancel');
+          Uri.parse(baseUrl).replace(path: '/order-items/$orderItemId/cancel');
 
       final response = await client
           .patch(
@@ -142,7 +142,7 @@ class OrderItemRemoteDataSourceImpl implements OrderItemRemoteDataSource {
   Future<OrderItemModel> processOrderItem(
       String token, String orderItemId) async {
     try {
-      final url = Uri.parse(BASE_URL)
+      final url = Uri.parse(baseUrl)
           .replace(path: '/order-items/$orderItemId/process');
 
       final response = await client
@@ -171,7 +171,7 @@ class OrderItemRemoteDataSourceImpl implements OrderItemRemoteDataSource {
       {required String airwaybill}) async {
     try {
       final url =
-          Uri.parse(BASE_URL).replace(path: '/order-items/$orderItemId/send');
+          Uri.parse(baseUrl).replace(path: '/order-items/$orderItemId/send');
 
       final response = await client
           .patch(
@@ -199,7 +199,7 @@ class OrderItemRemoteDataSourceImpl implements OrderItemRemoteDataSource {
   Future<OrderItemModel> completeOrderItem(
       String token, String orderItemId) async {
     try {
-      final url = Uri.parse(BASE_URL)
+      final url = Uri.parse(baseUrl)
           .replace(path: '/order-items/$orderItemId/complete');
 
       final response = await client

--- a/tocopedia-flutter/lib/data/data_sources/order_remote_data_source.dart
+++ b/tocopedia-flutter/lib/data/data_sources/order_remote_data_source.dart
@@ -27,7 +27,7 @@ class OrderRemoteDataSourceImpl implements OrderRemoteDataSource {
   @override
   Future<OrderModel> checkout(String token, String addressId) async {
     try {
-      final url = Uri.parse(BASE_URL).replace(path: '/orders/checkout');
+      final url = Uri.parse(baseUrl).replace(path: '/orders/checkout');
 
       final response = await client
           .post(
@@ -54,7 +54,7 @@ class OrderRemoteDataSourceImpl implements OrderRemoteDataSource {
   @override
   Future<OrderModel> payOrder(String token, String orderId) async {
     try {
-      final url = Uri.parse(BASE_URL).replace(path: '/orders/$orderId/pay');
+      final url = Uri.parse(baseUrl).replace(path: '/orders/$orderId/pay');
 
       final response = await client
           .patch(
@@ -80,7 +80,7 @@ class OrderRemoteDataSourceImpl implements OrderRemoteDataSource {
   @override
   Future<OrderModel> cancelOrder(String token, String orderId) async {
     try {
-      final url = Uri.parse(BASE_URL).replace(path: '/orders/$orderId/cancel');
+      final url = Uri.parse(baseUrl).replace(path: '/orders/$orderId/cancel');
 
       final response = await client
           .patch(
@@ -106,7 +106,7 @@ class OrderRemoteDataSourceImpl implements OrderRemoteDataSource {
   @override
   Future<OrderModel> getOrder(String token, String orderId) async {
     try {
-      final url = Uri.parse(BASE_URL).replace(path: '/orders/$orderId');
+      final url = Uri.parse(baseUrl).replace(path: '/orders/$orderId');
 
       final response = await client
           .get(
@@ -132,7 +132,7 @@ class OrderRemoteDataSourceImpl implements OrderRemoteDataSource {
   @override
   Future<List<OrderModel>> getUserOrders(String token) async {
     try {
-      final url = Uri.parse(BASE_URL).replace(path: '/orders');
+      final url = Uri.parse(baseUrl).replace(path: '/orders');
 
       final response = await client
           .get(

--- a/tocopedia-flutter/lib/data/data_sources/product_remote_data_source.dart
+++ b/tocopedia-flutter/lib/data/data_sources/product_remote_data_source.dart
@@ -58,7 +58,7 @@ class ProductRemoteDataSourceImpl implements ProductRemoteDataSource {
   @override
   Future<ProductModel> getProduct(String id) async {
     try {
-      final url = Uri.parse(BASE_URL).replace(path: '/products/$id');
+      final url = Uri.parse(baseUrl).replace(path: '/products/$id');
 
       final response = await client
           .get(url, headers: defaultHeader)
@@ -96,7 +96,7 @@ class ProductRemoteDataSourceImpl implements ProductRemoteDataSource {
       }..removeWhere((key, value) => value == null || value.toString().isEmpty))
           .map((key, value) => MapEntry(key, value.toString()));
 
-      final url = Uri.parse(BASE_URL).replace(
+      final url = Uri.parse(baseUrl).replace(
         path: '/products/search',
         queryParameters: queryParams,
       );
@@ -123,7 +123,7 @@ class ProductRemoteDataSourceImpl implements ProductRemoteDataSource {
   @override
   Future<List<ProductModel>> getPopularProducts() async {
     try {
-      final url = Uri.parse(BASE_URL).replace(
+      final url = Uri.parse(baseUrl).replace(
         path: '/products/popular',
       );
 
@@ -166,7 +166,7 @@ class ProductRemoteDataSourceImpl implements ProductRemoteDataSource {
       }..removeWhere(
           (key, value) => value == null || value.toString().isEmpty));
 
-      final url = Uri.parse(BASE_URL).replace(path: '/products');
+      final url = Uri.parse(baseUrl).replace(path: '/products');
 
       final response = await client
           .post(
@@ -194,7 +194,7 @@ class ProductRemoteDataSourceImpl implements ProductRemoteDataSource {
   @override
   Future<List<ProductModel>> getUserProducts(String token) async {
     try {
-      final url = Uri.parse(BASE_URL).replace(path: '/products/seller');
+      final url = Uri.parse(baseUrl).replace(path: '/products/seller');
 
       final response = await client
           .get(
@@ -251,7 +251,7 @@ class ProductRemoteDataSourceImpl implements ProductRemoteDataSource {
       }..removeWhere(
           (key, value) => value == null || value.toString().isEmpty));
 
-      final url = Uri.parse(BASE_URL).replace(path: '/products/$productId');
+      final url = Uri.parse(baseUrl).replace(path: '/products/$productId');
 
       final response = await client
           .patch(
@@ -279,7 +279,7 @@ class ProductRemoteDataSourceImpl implements ProductRemoteDataSource {
   @override
   Future<ProductModel> deleteProduct(String token, String productId) async {
     try {
-      final url = Uri.parse(BASE_URL).replace(path: '/products/$productId');
+      final url = Uri.parse(baseUrl).replace(path: '/products/$productId');
 
       final response = await client
           .delete(

--- a/tocopedia-flutter/lib/data/data_sources/remote_storage_service.dart
+++ b/tocopedia-flutter/lib/data/data_sources/remote_storage_service.dart
@@ -19,7 +19,7 @@ class RemoteStorageServiceImpl implements RemoteStorageService {
     final extension = _getExtension(imageFile.path);
     final contentType = _getContentType(extension);
 
-    final presignUri = Uri.parse('$BASE_URL/upload/presign').replace(
+    final presignUri = Uri.parse('$baseUrl/upload/presign').replace(
       queryParameters: {
         'contentType': contentType,
         'extension': extension,

--- a/tocopedia-flutter/lib/data/data_sources/review_remote_data_source.dart
+++ b/tocopedia-flutter/lib/data/data_sources/review_remote_data_source.dart
@@ -58,7 +58,7 @@ class ReviewRemoteDataSourceImpl implements ReviewRemoteDataSource {
           (key, value) => value == null || value.toString().isEmpty));
 
       final url =
-          Uri.parse(BASE_URL).replace(path: '/reviews/$orderItemDetailId');
+          Uri.parse(baseUrl).replace(path: '/reviews/$orderItemDetailId');
 
       final response = await client
           .post(
@@ -98,7 +98,7 @@ class ReviewRemoteDataSourceImpl implements ReviewRemoteDataSource {
       }..removeWhere(
           (key, value) => value == null || value.toString().isEmpty));
 
-      final url = Uri.parse(BASE_URL).replace(path: '/reviews/$reviewId');
+      final url = Uri.parse(baseUrl).replace(path: '/reviews/$reviewId');
 
       final response = await client
           .patch(
@@ -126,7 +126,7 @@ class ReviewRemoteDataSourceImpl implements ReviewRemoteDataSource {
   @override
   Future<List<ReviewModel>> getBuyerReviews(String token) async {
     try {
-      final url = Uri.parse(BASE_URL).replace(path: '/reviews/buyer');
+      final url = Uri.parse(baseUrl).replace(path: '/reviews/buyer');
 
       final response = await client
           .get(
@@ -155,7 +155,7 @@ class ReviewRemoteDataSourceImpl implements ReviewRemoteDataSource {
   Future<List<ReviewModel>> getProductReviews(String productId) async {
     try {
       final url =
-          Uri.parse(BASE_URL).replace(path: '/reviews/products/$productId');
+          Uri.parse(baseUrl).replace(path: '/reviews/products/$productId');
 
       final response = await client
           .get(
@@ -183,7 +183,7 @@ class ReviewRemoteDataSourceImpl implements ReviewRemoteDataSource {
   Future<List<ReviewModel>> getSellerReviews(String sellerId) async {
     try {
       final url =
-          Uri.parse(BASE_URL).replace(path: '/reviews/seller/$sellerId');
+          Uri.parse(baseUrl).replace(path: '/reviews/seller/$sellerId');
 
       final response = await client
           .get(
@@ -210,7 +210,7 @@ class ReviewRemoteDataSourceImpl implements ReviewRemoteDataSource {
   @override
   Future<ReviewModel> getReview(String reviewId) async {
     try {
-      final url = Uri.parse(BASE_URL).replace(path: '/reviews/$reviewId');
+      final url = Uri.parse(baseUrl).replace(path: '/reviews/$reviewId');
 
       final response = await client
           .get(

--- a/tocopedia-flutter/lib/data/data_sources/user_remote_data_source.dart
+++ b/tocopedia-flutter/lib/data/data_sources/user_remote_data_source.dart
@@ -25,7 +25,7 @@ class UserRemoteDataSourceImpl implements UserRemoteDataSource {
   @override
   Future<UserModel> signUp(String email, String password, String name) async {
     try {
-      final url = Uri.parse(BASE_URL).replace(path: '/auth/signup');
+      final url = Uri.parse(baseUrl).replace(path: '/auth/signup');
 
       final response = await client
           .post(
@@ -55,7 +55,7 @@ class UserRemoteDataSourceImpl implements UserRemoteDataSource {
   @override
   Future<UserModel> login(String email, String password) async {
     try {
-      final url = Uri.parse(BASE_URL).replace(path: '/auth/login');
+      final url = Uri.parse(baseUrl).replace(path: '/auth/login');
 
       final response = await client
           .post(
@@ -84,7 +84,7 @@ class UserRemoteDataSourceImpl implements UserRemoteDataSource {
   @override
   Future<UserModel> getUser(String token) async {
     try {
-      final url = Uri.parse(BASE_URL).replace(path: '/users');
+      final url = Uri.parse(baseUrl).replace(path: '/users');
 
       final response = await client
           .get(
@@ -112,7 +112,7 @@ class UserRemoteDataSourceImpl implements UserRemoteDataSource {
   Future<UserModel> updateUser(String token,
       {String? name, String? addressId}) async {
     try {
-      final url = Uri.parse(BASE_URL).replace(path: '/users');
+      final url = Uri.parse(baseUrl).replace(path: '/users');
       final response = await client
           .patch(
             url,

--- a/tocopedia-flutter/lib/data/data_sources/wishlist_remote_data_source.dart
+++ b/tocopedia-flutter/lib/data/data_sources/wishlist_remote_data_source.dart
@@ -23,7 +23,7 @@ class WishlistRemoteDataSourceImpl implements WishlistRemoteDataSource {
   @override
   Future<WishlistModel> addWishlist(String token, String productId) async {
     try {
-      final url = Uri.parse(BASE_URL).replace(path: '/wishlist/$productId');
+      final url = Uri.parse(baseUrl).replace(path: '/wishlist/$productId');
 
       final response = await client
           .post(
@@ -49,7 +49,7 @@ class WishlistRemoteDataSourceImpl implements WishlistRemoteDataSource {
   @override
   Future<WishlistModel> deleteWishlist(String token, String productId) async {
     try {
-      final url = Uri.parse(BASE_URL).replace(path: '/wishlist/$productId');
+      final url = Uri.parse(baseUrl).replace(path: '/wishlist/$productId');
 
       final response = await client
           .delete(
@@ -75,7 +75,7 @@ class WishlistRemoteDataSourceImpl implements WishlistRemoteDataSource {
   @override
   Future<WishlistModel> getWishlist(String token) async {
     try {
-      final url = Uri.parse(BASE_URL).replace(path: '/wishlist');
+      final url = Uri.parse(baseUrl).replace(path: '/wishlist');
 
       final response = await client
           .get(

--- a/tocopedia-flutter/lib/data/models/product_model.dart
+++ b/tocopedia-flutter/lib/data/models/product_model.dart
@@ -191,9 +191,7 @@ class ProductModel {
           : CategoryModel.fromMap(map['category']),
       totalSold: map['total_sold'],
       totalRating: map['total_rating'],
-      averageRating: map['average_rating'] == null
-          ? null
-          : map['average_rating']!.toDouble(),
+      averageRating: map['average_rating']?.toDouble(),
       createdAt:
           map['createdAt'] == null ? null : DateTime.parse(map['createdAt']),
       updatedAt:

--- a/tocopedia-flutter/lib/presentation/pages/features/order/view_order_page.dart
+++ b/tocopedia-flutter/lib/presentation/pages/features/order/view_order_page.dart
@@ -99,8 +99,7 @@ class _ViewOrderPageState extends State<ViewOrderPage> {
         Text(orderItem.seller!.name!, style: theme.textTheme.titleMedium),
         const SizedBox(height: 10),
         ...orderItem.orderItemDetails!
-            .map((product) => _buildProductTile(product, theme))
-            .toList(),
+            .map((product) => _buildProductTile(product, theme)),
         const SizedBox(height: 15),
         Text("Shipment Address", style: theme.textTheme.titleSmall),
         Text(
@@ -176,7 +175,7 @@ class _ViewOrderPageState extends State<ViewOrderPage> {
                           return _buildOrderItemTile(
                               order.address!, orderItem, theme);
                         },
-                      ).toList(),
+                      ),
                       if (order.status! == "unpaid")
                         Row(
                           mainAxisAlignment: MainAxisAlignment.spaceAround,

--- a/tocopedia-flutter/lib/presentation/providers/product_provider.dart
+++ b/tocopedia-flutter/lib/presentation/providers/product_provider.dart
@@ -60,7 +60,7 @@ class ProductProvider with ChangeNotifier {
         _getProduct = getProduct,
         _authToken = authToken;
 
-  ProviderState _searchProductState = ProviderState.empty;
+  final ProviderState _searchProductState = ProviderState.empty;
 
   ProviderState get searchProductState => _searchProductState;
 

--- a/tocopedia-flutter/lib/presentation/providers/review_provider.dart
+++ b/tocopedia-flutter/lib/presentation/providers/review_provider.dart
@@ -55,7 +55,7 @@ class ReviewProvider with ChangeNotifier {
 
   ProviderState get getBuyerReviewsState => _getBuyerReviewsState;
 
-  ProviderState _getSellerReviewsState = ProviderState.empty;
+  final ProviderState _getSellerReviewsState = ProviderState.empty;
 
   ProviderState get getSellerReviewsState => _getSellerReviewsState;
 

--- a/tocopedia-flutter/test/data/data_sources/remote_storage_service_test.dart
+++ b/tocopedia-flutter/test/data/data_sources/remote_storage_service_test.dart
@@ -81,7 +81,7 @@ void main() {
       final uri = captured[0] as Uri;
       final headers = captured[1] as Map<String, String>;
 
-      expect(uri.toString(), startsWith('$BASE_URL/upload/presign'));
+      expect(uri.toString(), startsWith('$baseUrl/upload/presign'));
       expect(uri.queryParameters['contentType'], 'image/jpeg');
       expect(uri.queryParameters['extension'], '.jpg');
       expect(headers['Authorization'], 'Bearer $tToken');


### PR DESCRIPTION
## Summary
- Rename `BASE_URL` → `baseUrl` to comply with `constant_identifier_names` (affects 11 data source files + 1 test)
- Replace explicit null check with `?.` operator in `product_model.dart` (`prefer_null_aware_operators`)
- Remove unnecessary `.toList()` from two spread expressions in `view_order_page.dart` (`unnecessary_to_list_in_spreads`)
- Mark `_searchProductState` and `_getSellerReviewsState` as `final` (`prefer_final_fields`)

## Test plan
- [ ] CI `flutter analyze --no-fatal-infos` passes with 0 remaining non-deprecated issues
- [ ] `flutter build web` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)