### PR TITLE
fix: use flutter_bootstrap.js to fix indefinite splash on web

### DIFF
--- a/tocopedia-flutter/web/index.html
+++ b/tocopedia-flutter/web/index.html
@@ -30,11 +30,6 @@
   <title>tocopedia</title>
   <link rel="manifest" href="manifest.json">
 
-  <!-- This script adds the flutter initialization JS code -->
-  <script src="flutter.js" defer=""></script>
-  <!-- Preload main.dart.js so it downloads in parallel with flutter.js -->
-  <link rel="preload" href="main.dart.js" as="script">
-  
   <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" name="viewport">
   
   <style>
@@ -122,18 +117,6 @@
       <source srcset="splash/img/light-1x.png 1x, splash/img/light-2x.png 2x, splash/img/light-3x.png 3x, splash/img/light-4x.png 4x" media="(prefers-color-scheme: light)">
       <source srcset="splash/img/dark-1x.png 1x, splash/img/dark-2x.png 2x, splash/img/dark-3x.png 3x, splash/img/dark-4x.png 4x" media="(prefers-color-scheme: dark)">
       <img class="center" aria-hidden="true" src="splash/img/light-1x.png" alt="">
-  </picture>    
-  <script>
-    window.addEventListener('load', function(ev) {
-      _flutter.loader.load({
-        onEntrypointLoaded: function(engineInitializer) {
-          engineInitializer.initializeEngine().then(function(appRunner) {
-            appRunner.runApp();
-          });
-        }
-      });
-    });
-  </script>
-
-
+  </picture>
+  <script src="flutter_bootstrap.js" async></script>
 </body></html>


### PR DESCRIPTION
## Summary
- Production at https://tocopedia.com/ hung on the splash screen indefinitely after #64
- Root cause: #64 changed `index.html` to call `_flutter.loader.load(...)`, but the flutter.js shipped by the Flutter SDK used in CI only exposes the older `loadEntrypoint` — `load` was undefined, so the call threw silently and the engine never initialized
- Fix: replace the manual loader script with `<script src="flutter_bootstrap.js" async></script>`, the SDK-generated bootstrap that handles loader/entrypoint/renderer init regardless of which loader API the installed flutter.js exports

## Test plan
- [x] `flutter build web --release --tree-shake-icons` succeeds
- [x] Verified locally with `python3 -m http.server` — bootstrap, main.dart.js, canvaskit.js, canvaskit.wasm all load and the app renders past the splash
- [x] Confirm Cloudflare Pages deploy renders the app
- [x] Note: existing visitors with a stale `flutter_service_worker.js` may need a hard refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)